### PR TITLE
[#7] 후원 요청 및 메시지 전송 API 구현

### DIFF
--- a/server/src/main/java/com/example/tyfserver/common/dto/ErrorResponse.java
+++ b/server/src/main/java/com/example/tyfserver/common/dto/ErrorResponse.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class ErrorDto {
+public class ErrorResponse {
 
     private final String message;
 }

--- a/server/src/main/java/com/example/tyfserver/common/dto/ErrorResponse.java
+++ b/server/src/main/java/com/example/tyfserver/common/dto/ErrorResponse.java
@@ -1,11 +1,13 @@
 package com.example.tyfserver.common.dto;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class ErrorResponse {
 
     private final String message;
+
+    public ErrorResponse(final String message) {
+        this.message = message;
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -23,7 +23,7 @@ public class DonationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(donationService.createDonation(donationRequest));
     }
 
-    @PostMapping("{donationId}/messgaes")
+    @PostMapping("{donationId}/messages")
     public ResponseEntity<Void> addDonationMessage(@PathVariable Long donationId,
                                                    @RequestBody DonationMessageRequest donationMessageRequest) {
 

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -7,12 +7,10 @@ import com.example.tyfserver.donation.service.DonationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("/donations")
+@RestController()
+@RequestMapping("/donations")
 @RequiredArgsConstructor
 public class DonationController {
 

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -1,11 +1,13 @@
 package com.example.tyfserver.donation.controller;
 
+import com.example.tyfserver.donation.dto.DonationMessageRequest;
 import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.service.DonationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +21,15 @@ public class DonationController {
     @PostMapping
     public ResponseEntity<DonationResponse> createDonation(@RequestBody DonationRequest donationRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(donationService.createDonation(donationRequest));
+    }
+
+    @PostMapping("{donationId}/messgaes")
+    public ResponseEntity<Void> addDonationMessage(@PathVariable Long donationId,
+                                                   @RequestBody DonationMessageRequest donationMessageRequest) {
+
+        donationService.addMessageToDonation(donationId, donationMessageRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 }

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -1,0 +1,23 @@
+package com.example.tyfserver.donation.controller;
+
+import com.example.tyfserver.donation.dto.DonationRequest;
+import com.example.tyfserver.donation.dto.DonationResponse;
+import com.example.tyfserver.donation.service.DonationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/donations")
+@RequiredArgsConstructor
+public class DonationController {
+
+    private final DonationService donationService;
+
+    @PostMapping
+    public ResponseEntity<DonationResponse> createDonation(@RequestBody DonationRequest donationRequest) {
+        return ResponseEntity.ok(donationService.createDonation(donationRequest));
+    }
+
+}

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -4,6 +4,7 @@ import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.service.DonationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +18,7 @@ public class DonationController {
 
     @PostMapping
     public ResponseEntity<DonationResponse> createDonation(@RequestBody DonationRequest donationRequest) {
-        return ResponseEntity.ok(donationService.createDonation(donationRequest));
+        return ResponseEntity.status(HttpStatus.CREATED).body(donationService.createDonation(donationRequest));
     }
 
 }

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -35,4 +35,17 @@ public class Donation {
     public Long id() {
         return id;
     }
+
+    public String name() {
+        return this.name;
+    }
+
+    public String message() {
+        return this.message;
+    }
+
+    public void addMessage(String name, String message) {
+        this.name = name;
+        this.message = message;
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.math.BigInteger;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,17 +14,25 @@ public class Donation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private BigInteger amount;
+    private Long amount;
 
-    private String name;
+    private String name = "익명";
 
-    private String message;
+    private String message = "당신을 응원합니다.";
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Donation(BigInteger amount) {
+    public Donation(Long amount) {
         this.amount = amount;
+    }
+
+    public void to(final Member member) {
+        this.member = member;
+    }
+
+    public Long id() {
+        return id;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -2,11 +2,13 @@ package com.example.tyfserver.donation.domain;
 
 import com.example.tyfserver.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Donation {
 
@@ -30,18 +32,6 @@ public class Donation {
 
     public void to(final Member member) {
         this.member = member;
-    }
-
-    public Long id() {
-        return id;
-    }
-
-    public String name() {
-        return this.name;
-    }
-
-    public String message() {
-        return this.message;
     }
 
     public void addMessage(String name, String message) {

--- a/server/src/main/java/com/example/tyfserver/donation/dto/DonationMessageRequest.java
+++ b/server/src/main/java/com/example/tyfserver/donation/dto/DonationMessageRequest.java
@@ -1,0 +1,15 @@
+package com.example.tyfserver.donation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DonationMessageRequest {
+
+    private final String name;
+    private final String message;
+
+    public DonationMessageRequest(final String name, final String message) {
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/donation/dto/DonationRequest.java
+++ b/server/src/main/java/com/example/tyfserver/donation/dto/DonationRequest.java
@@ -1,0 +1,15 @@
+package com.example.tyfserver.donation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DonationRequest {
+
+    private final Long creatorId;
+    private final Long donationAmount;
+
+    public DonationRequest(final Long creatorId, final Long donationAmount) {
+        this.creatorId = creatorId;
+        this.donationAmount = donationAmount;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/donation/dto/DonationResponse.java
+++ b/server/src/main/java/com/example/tyfserver/donation/dto/DonationResponse.java
@@ -13,6 +13,6 @@ public class DonationResponse {
     }
 
     public static DonationResponse from(final Member member) {
-        return new DonationResponse(member.id());
+        return new DonationResponse(member.getId());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/dto/DonationResponse.java
+++ b/server/src/main/java/com/example/tyfserver/donation/dto/DonationResponse.java
@@ -1,0 +1,18 @@
+package com.example.tyfserver.donation.dto;
+
+import com.example.tyfserver.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class DonationResponse {
+
+    private final Long donationId;
+
+    public DonationResponse(final Long donationId) {
+        this.donationId = donationId;
+    }
+
+    public static DonationResponse from(final Member member) {
+        return new DonationResponse(member.id());
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/donation/repository/DonationRepository.java
+++ b/server/src/main/java/com/example/tyfserver/donation/repository/DonationRepository.java
@@ -1,0 +1,7 @@
+package com.example.tyfserver.donation.repository;
+
+import com.example.tyfserver.donation.domain.Donation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DonationRepository extends JpaRepository<Donation, Long> {
+}

--- a/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
+++ b/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
@@ -1,0 +1,30 @@
+package com.example.tyfserver.donation.service;
+
+import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.donation.dto.DonationRequest;
+import com.example.tyfserver.donation.dto.DonationResponse;
+import com.example.tyfserver.donation.repository.DonationRepository;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DonationService {
+
+    private final DonationRepository donationRepository;
+    private final MemberRepository memberRepository;
+
+    public DonationResponse createDonation(final DonationRequest donationRequest) {
+        Member member = memberRepository.findById(donationRequest.getCreatorId())
+                .orElseThrow(() -> new RuntimeException("error_donation_request"));
+
+        Donation donation = new Donation(donationRequest.getDonationAmount());
+        member.addDonation(donation);
+        member.addPoint(donationRequest.getDonationAmount());
+        return DonationResponse.from(member);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
+++ b/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.donation.service;
 
 import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.donation.dto.DonationMessageRequest;
 import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.repository.DonationRepository;
@@ -26,5 +27,12 @@ public class DonationService {
         member.addDonation(donation);
         member.addPoint(donationRequest.getDonationAmount());
         return DonationResponse.from(member);
+    }
+
+    public void addMessageToDonation(final Long donationId, final DonationMessageRequest donationMessageRequest) {
+        Donation donation = donationRepository.findById(donationId)
+                .orElseThrow(() -> new RuntimeException("error_donation_message_send"));
+
+        donation.addMessage(donationMessageRequest.getName(), donationMessageRequest.getMessage());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -21,7 +21,6 @@ public class Member {
     @Column(unique = true)
     private String email;
 
-    // todo Point VO 감싸기(최소값 0)
     @Embedded
     private Point point;
 

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.example.tyfserver.member.domain;
 import com.example.tyfserver.banner.domain.Banner;
 import com.example.tyfserver.donation.domain.Donation;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
@@ -40,15 +42,7 @@ public class Member {
         donation.to(this);
     }
 
-    public Long id() {
-        return this.id;
-    }
-
     public void addPoint(final long donationAmount) {
         this.point.add(donationAmount);
-    }
-
-    public boolean isSamePoint(final long amount) {
-        return point.isSamePoint(amount);
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -22,16 +22,34 @@ public class Member {
     private String email;
 
     // todo Point VO 감싸기(최소값 0)
-    private BigInteger point;
+    @Embedded
+    private Point point;
 
     @OneToMany(mappedBy = "member")
-    private List<Banner> banners = new ArrayList<>();
+    private final List<Banner> banners = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
-    private List<Donation> donations = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
+    private final List<Donation> donations = new ArrayList<>();
 
     public Member(String email) {
         this.email = email;
-        this.point = BigInteger.valueOf(0L);
+        this.point = new Point(0L);
+    }
+
+    public void addDonation(final Donation donation) {
+        this.donations.add(donation);
+        donation.to(this);
+    }
+
+    public Long id() {
+        return this.id;
+    }
+
+    public void addPoint(final long donationAmount) {
+        this.point.add(donationAmount);
+    }
+
+    public boolean isSamePoint(final long amount) {
+        return point.isSamePoint(amount);
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Point.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Point.java
@@ -1,10 +1,13 @@
 package com.example.tyfserver.member.domain;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 
+
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point {
@@ -17,9 +20,5 @@ public class Point {
 
     public void add(final long donationAmount) {
         this.point += donationAmount;
-    }
-
-    public boolean isSamePoint(final long amount) {
-        return this.point == amount;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Point.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Point.java
@@ -1,0 +1,25 @@
+package com.example.tyfserver.member.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Point {
+
+    private long point;
+
+    public Point(final long point) {
+        this.point = point;
+    }
+
+    public void add(final long donationAmount) {
+        this.point += donationAmount;
+    }
+
+    public boolean isSamePoint(final long amount) {
+        return this.point == amount;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.tyfserver.member.repository;
+
+import com.example.tyfserver.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -13,7 +13,9 @@ spring:
     hibernate:
       ddl-auto: create
 
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace
-

--- a/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
@@ -13,10 +13,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 class DonationRepositoryTest {
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
-    DonationRepository donationRepository;
+    private DonationRepository donationRepository;
 
     @DisplayName("후원을 등록한다.")
     @Test

--- a/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
@@ -9,10 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.math.BigInteger;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 @DataJpaTest
 class DonationRepositoryTest {
 

--- a/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
@@ -31,7 +31,7 @@ class DonationRepositoryTest {
         final Donation savedDonation = donationRepository.save(donation);
 
         //then
-        Assertions.assertNotNull(savedDonation.id());
+        Assertions.assertNotNull(savedDonation.getId());
     }
 
 }

--- a/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/repository/DonationRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.example.tyfserver.donation.repository;
+
+import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class DonationRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    DonationRepository donationRepository;
+
+    @DisplayName("후원을 등록한다.")
+    @Test
+    void createDonation() throws Exception {
+        //given
+        final Member member = new Member("tyf@gmail.com");
+        memberRepository.save(member);
+
+        final Donation donation = new Donation(1000L);
+
+        //when
+        final Donation savedDonation = donationRepository.save(donation);
+
+        //then
+        Assertions.assertNotNull(savedDonation.id());
+    }
+
+}

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -1,0 +1,70 @@
+package com.example.tyfserver.donation.service;
+
+import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.donation.dto.DonationRequest;
+import com.example.tyfserver.donation.dto.DonationResponse;
+import com.example.tyfserver.donation.repository.DonationRepository;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class DonationServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    DonationRepository donationRepository;
+
+    @Autowired
+    DonationService donationService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member("tyf@gmail.com");
+        memberRepository.save(member);
+    }
+
+    @DisplayName("후원을 등록한다.")
+    @Test
+    void createDonation() throws Exception {
+        //given
+        DonationRequest donationRequest = new DonationRequest(member.id(), 1000L);
+
+        //when
+        final DonationResponse donationResponse = donationService.createDonation(donationRequest);
+        //then
+        Assertions.assertEquals(member.id(), donationResponse.getDonationId());
+    }
+
+    @DisplayName("후원받은 포인트만큼 멤버의 포인트에 누적된다.")
+    @Test
+    void accumulateMemberPoint() throws Exception {
+        //given
+        DonationRequest donationRequest = new DonationRequest(member.id(), 1000L);
+
+        //when
+        donationService.createDonation(donationRequest);
+        //then
+        final Member findMember = memberRepository.findById(this.member.id()).get();
+        Assertions.assertTrue(findMember.isSamePoint(1000L));
+    }
+
+
+
+}

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -7,13 +7,14 @@ import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.repository.DonationRepository;
 import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.repository.MemberRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -40,25 +41,25 @@ class DonationServiceTest {
     @Test
     void createDonation() throws Exception {
         //given
-        DonationRequest donationRequest = new DonationRequest(member.id(), 1000L);
+        DonationRequest donationRequest = new DonationRequest(member.getId(), 1000L);
 
         //when
         DonationResponse donationResponse = donationService.createDonation(donationRequest);
         //then
-        Assertions.assertEquals(member.id(), donationResponse.getDonationId());
+        assertThat(member.getId()).isEqualTo(donationResponse.getDonationId());
     }
 
     @DisplayName("후원받은 포인트만큼 멤버의 포인트에 누적된다.")
     @Test
     void accumulateMemberPoint() throws Exception {
         //given
-        DonationRequest donationRequest = new DonationRequest(member.id(), 1000L);
+        DonationRequest donationRequest = new DonationRequest(member.getId(), 1000L);
 
         //when
         donationService.createDonation(donationRequest);
         //then
-        Member findMember = memberRepository.findById(this.member.id()).get();
-        Assertions.assertTrue(findMember.isSamePoint(1000L));
+        Member findMember = memberRepository.findById(this.member.getId()).get();
+        assertThat(1000L).isEqualTo(findMember.getPoint().getPoint());
     }
 
 
@@ -71,12 +72,11 @@ class DonationServiceTest {
         DonationMessageRequest donationMessageRequest = new DonationMessageRequest("test", "this is test message");
 
         //when
-        donationService.addMessageToDonation(savedDonation.id(), donationMessageRequest);
+        donationService.addMessageToDonation(savedDonation.getId(), donationMessageRequest);
 
         //then
-        final Donation findDonation = donationRepository.findById(savedDonation.id()).get();
-        Assertions.assertEquals(donationMessageRequest.getName(), findDonation.name());
-        Assertions.assertEquals(donationMessageRequest.getMessage(), findDonation.message());
-
+        final Donation findDonation = donationRepository.findById(savedDonation.getId()).get();
+        assertThat(donationMessageRequest.getName()).isEqualTo(findDonation.getName());
+        assertThat(donationMessageRequest.getMessage()).isEqualTo(findDonation.getMessage());
     }
 }

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -12,13 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.math.BigInteger;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -20,13 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 class DonationServiceTest {
 
     @Autowired
-    MemberRepository memberRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
-    DonationRepository donationRepository;
+    private DonationRepository donationRepository;
 
     @Autowired
-    DonationService donationService;
+    private DonationService donationService;
 
     private Member member;
 

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.donation.service;
 
 import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.donation.dto.DonationMessageRequest;
 import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.repository.DonationRepository;
@@ -47,7 +48,7 @@ class DonationServiceTest {
         DonationRequest donationRequest = new DonationRequest(member.id(), 1000L);
 
         //when
-        final DonationResponse donationResponse = donationService.createDonation(donationRequest);
+        DonationResponse donationResponse = donationService.createDonation(donationRequest);
         //then
         Assertions.assertEquals(member.id(), donationResponse.getDonationId());
     }
@@ -61,10 +62,26 @@ class DonationServiceTest {
         //when
         donationService.createDonation(donationRequest);
         //then
-        final Member findMember = memberRepository.findById(this.member.id()).get();
+        Member findMember = memberRepository.findById(this.member.id()).get();
         Assertions.assertTrue(findMember.isSamePoint(1000L));
     }
 
 
+    @DisplayName("후원 메시지를 추가한다.")
+    @Test
+    void addDonationMessage() throws Exception {
+        //given
+        Donation donation = new Donation(1000L);
+        final Donation savedDonation = donationRepository.save(donation);
+        DonationMessageRequest donationMessageRequest = new DonationMessageRequest("test", "this is test message");
 
+        //when
+        donationService.addMessageToDonation(savedDonation.id(), donationMessageRequest);
+
+        //then
+        final Donation findDonation = donationRepository.findById(savedDonation.id()).get();
+        Assertions.assertEquals(donationMessageRequest.getName(), findDonation.name());
+        Assertions.assertEquals(donationMessageRequest.getMessage(), findDonation.message());
+
+    }
 }


### PR DESCRIPTION
## 구현 설명

후원 요청 시 멤버를 찾고, 해당 멤버의 포인트를 올려준 뒤 후원 데이터를 DB에 저장. 후원 응답은 DB에 저장된 후원의 ID값을 전달.
클라이언트에서 해당 후원 ID와 함께 후원자 이름과 메시지를 담아 후원 메시지 전송 API로 요청.  
Point 객체 추가하고, 후원 시에 해당 Long point 값 변경이 이루어짐


## 후원 요청 API

### Reqeust

```json
{
	"creator_id": 1,
	"donation_amount" : 1000
}
```

### Response

```json
RESPONSE / success
201 CREATED

{
	"donation_id": 1,
}
```

```json
RESPONSE / error
400 BAD REQUEST

{
	"message": "error_donation_request"
}
```

## 후원 메시지 전송 API

### Request

```json
REQUEST

{
	"name": "userName",
	"message": "당신을 응원합니다."
}
```

### Response

```json
RESPONSE
201 CREATED

{}
```

```json
RESPONSE
400 BAD REQUEST

{
	"message": "error_donation_message_send"
}
```