### PR TITLE
[#77] 창작자가 자신의 정보를 조회하는 API를 작성한다.

### DIFF
--- a/server/src/main/java/com/example/tyfserver/auth/config/AuthenticationPrincipalConfig.java
+++ b/server/src/main/java/com/example/tyfserver/auth/config/AuthenticationPrincipalConfig.java
@@ -19,7 +19,7 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
                 // todo 인증 테스트 필요
-                .addPathPatterns("/banners", "/banners/me", "/donations/me", "/members/me/point");
+                .addPathPatterns("/banners", "/banners/me", "/donations/me", "/members/me", "/members/me/point");
     }
 
     @Override

--- a/server/src/main/java/com/example/tyfserver/auth/config/Oauth2Config.java
+++ b/server/src/main/java/com/example/tyfserver/auth/config/Oauth2Config.java
@@ -21,15 +21,15 @@ public class Oauth2Config {
 
     @PostConstruct
     public void inject() {
-        for (Oauth2Type value : Oauth2Type.values()) {
-            if (value.equals(Oauth2Type.GOOGLE)) {
-                value.setOauth2TypeInterface(googleOauth2);
+        for (Oauth2Type oauth2Type : Oauth2Type.values()) {
+            if (oauth2Type.equals(Oauth2Type.GOOGLE)) {
+                oauth2Type.setOauth2TypeInterface(googleOauth2);
             }
-            if (value.equals(Oauth2Type.NAVER)) {
-                value.setOauth2TypeInterface(naverOauth2);
+            if (oauth2Type.equals(Oauth2Type.NAVER)) {
+                oauth2Type.setOauth2TypeInterface(naverOauth2);
             }
-            if (value.equals(Oauth2Type.KAKAO)) {
-                value.setOauth2TypeInterface(kakaoOauth2);
+            if (oauth2Type.equals(Oauth2Type.KAKAO)) {
+                oauth2Type.setOauth2TypeInterface(kakaoOauth2);
             }
         }
     }

--- a/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
+++ b/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
@@ -1,10 +1,11 @@
 package com.example.tyfserver.auth.controller;
 
+import com.example.tyfserver.auth.dto.SignUpResponse;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.auth.exception.SignUpRequestException;
 import com.example.tyfserver.auth.service.Oauth2Service;
+import com.example.tyfserver.member.dto.SignUpReadyResponse;
 import com.example.tyfserver.member.dto.SignUpRequest;
-import com.example.tyfserver.member.dto.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -25,13 +26,13 @@ public class Oauth2Controller {
     }
 
     @GetMapping("/signup/ready/{oauth}")
-    public ResponseEntity<SignUpResponse> readySignUp(@PathVariable String oauth, @RequestParam String code) {
+    public ResponseEntity<SignUpReadyResponse> readySignUp(@PathVariable String oauth, @RequestParam String code) {
         return ResponseEntity.ok(oauth2Service.readySignUp(oauth, code));
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<TokenResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest,
-                                                BindingResult result) {
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest,
+                                                 BindingResult result) {
         if (result.hasErrors()) {
             throw new SignUpRequestException();
         }

--- a/server/src/main/java/com/example/tyfserver/auth/domain/Oauth2.java
+++ b/server/src/main/java/com/example/tyfserver/auth/domain/Oauth2.java
@@ -4,17 +4,17 @@ import org.json.JSONObject;
 
 public interface Oauth2 {
 
-    public String extractEmail(final JSONObject jsonObject);
+    String extractEmail(final JSONObject jsonObject);
 
-    public String getType();
+    String getType();
 
-    public String getClientId();
+    String getClientId();
 
-    public String getClientSecret();
+    String getClientSecret();
 
-    public String getRedirectUrl();
+    String getRedirectUrl();
 
-    public String getAccessTokenApi();
+    String getAccessTokenApi();
 
-    public String getProfileApi();
+    String getProfileApi();
 }

--- a/server/src/main/java/com/example/tyfserver/auth/dto/SignUpResponse.java
+++ b/server/src/main/java/com/example/tyfserver/auth/dto/SignUpResponse.java
@@ -1,0 +1,15 @@
+package com.example.tyfserver.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignUpResponse {
+
+    private String token;
+    private String pageName;
+
+    public SignUpResponse(String token, String pageName) {
+        this.token = token;
+        this.pageName = pageName;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/auth/exception/SignUpRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/auth/exception/SignUpRequestException.java
@@ -5,7 +5,7 @@ import com.example.tyfserver.common.exception.BaseException;
 public class SignUpRequestException extends BaseException {
 
     public static final String ERROR_CODE = "auth-007";
-    private static final String MESSAGE = "배너 생성 시에 넘기는 Request의 값이 유효한 값이 아닙니다.";
+    private static final String MESSAGE = "회원가입 Request의 값이 유효한 값이 아닙니다.";
 
     public SignUpRequestException() {
         super(ERROR_CODE, MESSAGE);

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -46,8 +46,8 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberPrivateResponse> memberPrivate(LoginMember loginMember) {
-        return ResponseEntity.ok(memberService.findMemberPrivate(loginMember.getId()));
+    public ResponseEntity<MemberDetailResponse> memberDetail(LoginMember loginMember) {
+        return ResponseEntity.ok(memberService.findMemberDetail(loginMember.getId()));
     }
 
     @GetMapping("/me/point")

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package com.example.tyfserver.member.controller;
 
 import com.example.tyfserver.auth.dto.LoginMember;
-import com.example.tyfserver.member.dto.MemberResponse;
-import com.example.tyfserver.member.dto.NicknameValidationRequest;
-import com.example.tyfserver.member.dto.PageNameValidationRequest;
-import com.example.tyfserver.member.dto.PointResponse;
+import com.example.tyfserver.member.dto.*;
 import com.example.tyfserver.member.exception.NicknameValidationRequestException;
 import com.example.tyfserver.member.exception.PageNameValidationRequestException;
 import com.example.tyfserver.member.service.MemberService;
@@ -46,6 +43,11 @@ public class MemberController {
     @GetMapping("/{pageName}")
     public ResponseEntity<MemberResponse> memberInfo(@PathVariable String pageName) {
         return ResponseEntity.ok(memberService.findMember(pageName));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberPrivateResponse> memberPrivate(LoginMember loginMember) {
+        return ResponseEntity.ok(memberService.findMemberPrivate(loginMember.getId()));
     }
 
     @GetMapping("/me/point")

--- a/server/src/main/java/com/example/tyfserver/member/dto/MemberDetailResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/MemberDetailResponse.java
@@ -4,17 +4,17 @@ import com.example.tyfserver.member.domain.Member;
 import lombok.Getter;
 
 @Getter
-public class MemberPrivateResponse {
+public class MemberDetailResponse {
 
     private String email;
     private String nickname;
     private String pageName;
 
-    public MemberPrivateResponse(Member member) {
+    public MemberDetailResponse(Member member) {
         this(member.getEmail(), member.getNickname(), member.getPageName());
     }
 
-    public MemberPrivateResponse(String email, String nickname, String pageName) {
+    public MemberDetailResponse(String email, String nickname, String pageName) {
         this.email = email;
         this.nickname = nickname;
         this.pageName = pageName;

--- a/server/src/main/java/com/example/tyfserver/member/dto/MemberPrivateResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/MemberPrivateResponse.java
@@ -1,0 +1,22 @@
+package com.example.tyfserver.member.dto;
+
+import com.example.tyfserver.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberPrivateResponse {
+
+    private String email;
+    private String nickname;
+    private String pageName;
+
+    public MemberPrivateResponse(Member member) {
+        this(member.getEmail(), member.getNickname(), member.getPageName());
+    }
+
+    public MemberPrivateResponse(String email, String nickname, String pageName) {
+        this.email = email;
+        this.nickname = nickname;
+        this.pageName = pageName;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/member/dto/SignUpReadyResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/SignUpReadyResponse.java
@@ -3,12 +3,12 @@ package com.example.tyfserver.member.dto;
 import lombok.Getter;
 
 @Getter
-public class SignUpResponse {
+public class SignUpReadyResponse {
 
     private String email;
     private String oauthType;
 
-    public SignUpResponse(String email, String oauthType) {
+    public SignUpReadyResponse(String email, String oauthType) {
         this.email = email;
         this.oauthType = oauthType;
     }

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -30,19 +30,19 @@ public class MemberService {
     }
 
     public MemberResponse findMember(String pageName) {
-        Member findMember = memberRepository.findByPageName(pageName)
+        Member member = memberRepository.findByPageName(pageName)
                 .orElseThrow(MemberNotFoundException::new);
-        return new MemberResponse(findMember);
+        return new MemberResponse(member);
     }
 
-    public MemberPrivateResponse findMemberPrivate(Long id) {
-        Member findMember = findMember(id);
-        return new MemberPrivateResponse(findMember);
+    public MemberDetailResponse findMemberDetail(Long id) {
+        Member member = findMember(id);
+        return new MemberDetailResponse(member);
     }
 
     public PointResponse findMemberPoint(Long id) {
-        Member findMember = findMember(id);
-        return new PointResponse(findMember.getPoint().getPoint());
+        Member member = findMember(id);
+        return new PointResponse(member.getPoint().getPoint());
     }
 
     private Member findMember(Long id) {

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -1,10 +1,7 @@
 package com.example.tyfserver.member.service;
 
 import com.example.tyfserver.member.domain.Member;
-import com.example.tyfserver.member.dto.MemberResponse;
-import com.example.tyfserver.member.dto.NicknameValidationRequest;
-import com.example.tyfserver.member.dto.PageNameValidationRequest;
-import com.example.tyfserver.member.dto.PointResponse;
+import com.example.tyfserver.member.dto.*;
 import com.example.tyfserver.member.exception.DuplicatedNicknameException;
 import com.example.tyfserver.member.exception.DuplicatedPageNameException;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
@@ -32,20 +29,24 @@ public class MemberService {
         }
     }
 
-    public Member findMember(Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(MemberNotFoundException::new);
-    }
-
     public MemberResponse findMember(String pageName) {
         Member findMember = memberRepository.findByPageName(pageName)
                 .orElseThrow(MemberNotFoundException::new);
         return new MemberResponse(findMember);
     }
 
+    public MemberPrivateResponse findMemberPrivate(Long id) {
+        Member findMember = findMember(id);
+        return new MemberPrivateResponse(findMember);
+    }
+
     public PointResponse findMemberPoint(Long id) {
-        Member findMember = memberRepository.findById(id)
-                .orElseThrow(MemberNotFoundException::new);
+        Member findMember = findMember(id);
         return new PointResponse(findMember.getPoint().getPoint());
+    }
+
+    private Member findMember(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
@@ -104,12 +104,12 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("창작자 자신의 정보 조회")
     public void getMemberInfoSelf() {
         String token = jwtTokenProvider.createToken(member.getId(), member.getEmail());
-        MemberPrivateResponse memberResponse = authGet("/members/me", token)
+        MemberDetailResponse memberResponse = authGet("/members/me", token)
                 .statusCode(HttpStatus.OK.value())
-                .extract().as(MemberPrivateResponse.class);
+                .extract().as(MemberDetailResponse.class);
 
         assertThat(memberResponse).usingRecursiveComparison()
-                .isEqualTo(new MemberPrivateResponse(member));
+                .isEqualTo(new MemberDetailResponse(member));
     }
 
     @Test

--- a/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
@@ -2,13 +2,11 @@ package com.example.tyfserver.member;
 
 import com.example.tyfserver.AcceptanceTest;
 import com.example.tyfserver.auth.exception.AuthorizationHeaderNotFoundException;
+import com.example.tyfserver.auth.exception.InvalidTokenException;
 import com.example.tyfserver.auth.util.JwtTokenProvider;
 import com.example.tyfserver.common.dto.ErrorResponse;
 import com.example.tyfserver.member.domain.Member;
-import com.example.tyfserver.member.dto.MemberResponse;
-import com.example.tyfserver.member.dto.NicknameValidationRequest;
-import com.example.tyfserver.member.dto.PageNameValidationRequest;
-import com.example.tyfserver.member.dto.PointResponse;
+import com.example.tyfserver.member.dto.*;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.example.tyfserver.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -23,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MemberAcceptanceTest extends AcceptanceTest {
 
     private static final String INVALID_PAGE_NAME = "INVALID_PAGE_NAME";
+    private static final String INVALID_TOKEN = "INVALID_TOKEN";
 
     @Autowired
     private MemberRepository memberRepository;
@@ -31,12 +30,14 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     private JwtTokenProvider jwtTokenProvider;
 
     private Member member = MemberTest.testMember();
+    private Member member2 = MemberTest.testMember2();
 
     @Override
     @BeforeEach
     public void setUp() {
         super.setUp();
         member = memberRepository.save(member);
+        member2 = memberRepository.save(member2);
     }
 
     @AfterEach
@@ -53,7 +54,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("랜딩 페이지 유효성 검사 - 실패의 경우")
+    @DisplayName("랜딩 페이지 유효성 검사 - 실패")
     public void validateLandingPageValidationWithNotValidCase() {
         PageNameValidationRequest validationRequest = new PageNameValidationRequest("ㅁㄴㅇㄹ");
         post("/members/validate/pageName", validationRequest)
@@ -70,7 +71,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("닉네임 유효성 검사 - 실패의 경우")
+    @DisplayName("닉네임 유효성 검사 - 실패")
     public void validateNicknameValidationWithNotValidCase() {
         NicknameValidationRequest validationRequest = new NicknameValidationRequest("NotValidNickname!!");
         post("/members/validate/nickname", validationRequest)
@@ -89,7 +90,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("창작자 정보 조회 - 실패: 인증헤더 없음")
+    @DisplayName("창작자 정보 조회 - 실패: 존재하지 않는 멤버")
     public void getMemberInfo_fail() {
         ErrorResponse error = get("/members/" + INVALID_PAGE_NAME)
                 .statusCode(HttpStatus.BAD_REQUEST.value())
@@ -97,6 +98,40 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         assertThat(error.getErrorCode())
                 .isEqualTo(MemberNotFoundException.ERROR_CODE);
+    }
+
+    @Test
+    @DisplayName("창작자 자신의 정보 조회")
+    public void getMemberInfoSelf() {
+        String token = jwtTokenProvider.createToken(member.getId(), member.getEmail());
+        MemberPrivateResponse memberResponse = authGet("/members/me", token)
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(MemberPrivateResponse.class);
+
+        assertThat(memberResponse).usingRecursiveComparison()
+                .isEqualTo(new MemberPrivateResponse(member));
+    }
+
+    @Test
+    @DisplayName("창작자 자신의 정보 조회 - 실패: 인증헤더 없음")
+    public void getMemberInfoSelf_fail1() {
+        ErrorResponse error = get("/members/me")
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .extract().as(ErrorResponse.class);
+
+        assertThat(error.getErrorCode())
+                .isEqualTo(AuthorizationHeaderNotFoundException.ERROR_CODE);
+    }
+
+    @Test
+    @DisplayName("창작자 자신의 정보 조회 - 실패: 유효하지 않은 토큰")
+    public void getMemberInfoSelf_fail2() {
+        ErrorResponse error = authGet("/members/me", INVALID_TOKEN)
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .extract().as(ErrorResponse.class);
+
+        assertThat(error.getErrorCode())
+                .isEqualTo(InvalidTokenException.ERROR_CODE);
     }
 
     @Test


### PR DESCRIPTION
close #77

1. 이미 `MemberResponse`가 있어서 자신만 볼수있는 비공개 정보는 `MemberPrivateResponse`라고 이름지었는데 다른 좋은 의견있으면 많이 내주세요!ㅎㅎ
2. 아직은 `MemberPrivateResponse`만 가지고 있는 비공개 정보가 딱히 없어서 `MemberResponse`와 똑같긴해요. 나중에 생길테니까 미리 분리해놨어요.
3. 기존의 `SignUpResponse`를 `SignUpReadyResponse`로 변경하고 token과 pageName을 담는 `SignUpResponse`를 새로 만들었어요.