### PR TITLE
[#84] 후원금 순 큐레이션 리스트를 보여준다.

### DIFF
--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 
 @RestController
@@ -53,5 +54,10 @@ public class MemberController {
     @GetMapping("/me/point")
     public ResponseEntity<PointResponse> memberPoint(LoginMember loginMember) {
         return ResponseEntity.ok(memberService.findMemberPoint(loginMember.getId()));
+    }
+
+    @GetMapping("/curations")
+    public ResponseEntity<List<CurationsResponse>> curations() {
+        return ResponseEntity.ok(memberService.findCurations());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/dto/CurationsResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/CurationsResponse.java
@@ -4,17 +4,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Objects;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CurationsResponse {
 
     private String nickname;
     private Long donationAmount;
+    private String pageName;
 
-    public CurationsResponse(String nickname, Long donationAmount) {
+    public CurationsResponse(String nickname, Long donationAmount, String pageName) {
         this.nickname = nickname;
         this.donationAmount = donationAmount;
+        this.pageName = pageName;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/dto/CurationsResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/CurationsResponse.java
@@ -1,0 +1,20 @@
+package com.example.tyfserver.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CurationsResponse {
+
+    private String nickname;
+    private Long donationAmount;
+
+    public CurationsResponse(String nickname, Long donationAmount) {
+        this.nickname = nickname;
+        this.donationAmount = donationAmount;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
@@ -1,0 +1,9 @@
+package com.example.tyfserver.member.repository;
+
+import com.example.tyfserver.member.dto.CurationsResponse;
+
+import java.util.List;
+
+public interface MemberQueryRepository {
+    List<CurationsResponse> findCurations();
+}

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
 
     Optional<Member> findByEmail(String email);
 

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -14,7 +14,8 @@ public class MemberRepositoryImpl implements MemberQueryRepository{
     @Override
     public List<CurationsResponse> findCurations() {
         return em.createQuery(
-                "select new com.example.tyfserver.member.dto.CurationsResponse(d.member.nickname, sum(d.amount)) " +
+                "select new com.example.tyfserver.member.dto.CurationsResponse(" +
+                        "           d.member.nickname, sum(d.amount), d.member.pageName) " +
                         "from Donation d " +
                         "join d.member " +
                         "group by d.member " +

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.example.tyfserver.member.repository;
+
+import com.example.tyfserver.member.dto.CurationsResponse;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberQueryRepository{
+
+    private final EntityManager em;
+
+    @Override
+    public List<CurationsResponse> findCurations() {
+        return em.createQuery(
+                "select new com.example.tyfserver.member.dto.CurationsResponse(d.member.nickname, sum(d.amount)) " +
+                        "from Donation d " +
+                        "join d.member " +
+                        "group by d.member " +
+                        "order by sum(d.amount) desc ",
+                CurationsResponse.class
+        )
+                .setFirstResult(0)
+                .setMaxResults(5)
+                .getResultList();
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -48,5 +50,9 @@ public class MemberService {
     private Member findMember(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+
+    public List<CurationsResponse> findCurations() {
+        return memberRepository.findCurations();
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
@@ -66,11 +66,11 @@ class MemberRepositoryImplTest {
         em.clear();
 
         List<CurationsResponse> curations = memberRepository.findCurations();
-        assertThat(curations.get(0)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname6", 13000L));
-        assertThat(curations.get(1)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname3", 7000L));
-        assertThat(curations.get(2)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname5", 5000L));
-        assertThat(curations.get(3)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname2", 2000L));
-        assertThat(curations.get(4)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname1", 1000L));
+        assertThat(curations.get(0)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname6", 13000L, "pageName6"));
+        assertThat(curations.get(1)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname3", 7000L, "pageName3"));
+        assertThat(curations.get(2)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname5", 5000L, "pageName5"));
+        assertThat(curations.get(3)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname2", 2000L, "pageName2"));
+        assertThat(curations.get(4)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname1", 1000L, "pageName111111"));
     }
 
 }

--- a/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
@@ -1,0 +1,76 @@
+package com.example.tyfserver.member.repository;
+
+import com.example.tyfserver.auth.domain.Oauth2Type;
+import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.donation.domain.Message;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.dto.CurationsResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class MemberRepositoryImplTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void curationListTest() {
+
+        Member member1 = new Member("email1", "nickname1", "pageName1", Oauth2Type.GOOGLE);
+        Member member2 = new Member("email2", "nickname2", "pageName2", Oauth2Type.GOOGLE);
+        Member member3 = new Member("email3", "nickname3", "pageName3", Oauth2Type.GOOGLE);
+        Member member4 = new Member("email4", "nickname4", "pageName4", Oauth2Type.GOOGLE);
+        Member member5 = new Member("email5", "nickname5", "pageName5", Oauth2Type.GOOGLE);
+        Member member6 = new Member("email6", "nickname6", "pageName6", Oauth2Type.GOOGLE);
+
+        Donation donation1 = new Donation(1000L, Message.defaultMessage());
+        Donation donation2 = new Donation(2000L, Message.defaultMessage());
+        Donation donation3 = new Donation(3000L, Message.defaultMessage());
+        Donation donation4 = new Donation(4000L, Message.defaultMessage());
+        Donation donation5 = new Donation(5000L, Message.defaultMessage());
+        Donation donation6 = new Donation(6000L, Message.defaultMessage());
+        Donation donation7 = new Donation(7000L, Message.defaultMessage());
+
+        //member1 1000 member2 2000, member3 7000, member4 0, member5 5000, member6 13000
+        member1.addDonation(donation1);
+        member2.addDonation(donation2);
+        member3.addDonation(donation3);
+        member3.addDonation(donation4);
+        member5.addDonation(donation5);
+        member6.addDonation(donation6);
+        member6.addDonation(donation7);
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+        em.persist(member5);
+        em.persist(member6);
+        em.persist(donation1);
+        em.persist(donation2);
+        em.persist(donation3);
+        em.persist(donation4);
+        em.persist(donation5);
+        em.persist(donation6);
+        em.persist(donation7);
+        em.flush();
+        em.clear();
+
+        List<CurationsResponse> curations = memberRepository.findCurations();
+        assertThat(curations.get(0)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname6", 13000L));
+        assertThat(curations.get(1)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname3", 7000L));
+        assertThat(curations.get(2)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname5", 5000L));
+        assertThat(curations.get(3)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname2", 2000L));
+        assertThat(curations.get(4)).usingRecursiveComparison().isEqualTo(new CurationsResponse("nickname1", 1000L));
+    }
+
+}


### PR DESCRIPTION
방식들을 생각하느라 조금 늦었습니다!  지금까지 받은 후원금액 top5 멤버의 닉네임과 총 금액을 갖고왔습니다.  

처음에는 멤버에 대한 정보를 가지고 올 때에 도네이션을 페치 조인해서 service 내부에서 금액들을 합치고 정렬하고 상위 5명을 뽑아서 dto로 변환 후 return 해주는 방식을 생각했으나 쿼리로 처리할 수 있는 부분이기 이 방식은 버려졌습니다.  

그 후 생각한 방식은 도네이션 테이블에서 멤버로 그룹지어서 sum(amount) 해서 member_id와 sum(amount)를 갖고온 뒤에 이 member_id를 따로 멤버 테이블에 조회하는 방식이었습니다. 인라인 서브쿼리를 사용해야 된다고 생각했는데, jpa는 인라인 서브쿼리를 지원하지 않기 때문에 쿼리를 2번에 나눠 진행해야 한다고 생각했고 이 또한 service에 로직을 두지말고 repository 에서 처리해야 된다고 생각했습니다. 그러나 쿼리 2번 나가야 하는건 착각이었고 1번에 끌고 올 수 있었습니다.  
Member를 들고오는 것이 아니라 nickname과 sum(amount)에 관한 값만 들고와야 했기 때문에 Dto를 리턴하는 식으로 진행했습니다.  
가지고오는 데이터 수를 5개로 제한해야 했기도 했고 쿼리를 ``@Query`` 내에 적기 조금 길었기 때문에 따로 사용자 정의 레포지터리를 만들어서 진행했습니다.  

사용자 정의 레포지터리에 대해 간략히 설명하겠습니다.  
기존에 저희는 ``public interface MemberRepository extends JpaRepository<Member, Long>`` 의 레포지터리를 사용했습니다.  
그런데 만약 복잡한 쿼리라던가, jpql이 아닌 네이티브 쿼리를 사용한다던가, queryDsl를 사용한다던가 등등의 경우에는 위의 레포지터리를 사용하기가 굉장히 애매합니다. 이때 사용하는 것이 사용자 정의 레포지터리입니다.  
![image](https://user-images.githubusercontent.com/45073750/125885469-e553d8d7-eab8-4b25-a0f2-a850b99fb654.png)
다음과 같이 인터페이스를 하나 새롭게 만들고,  
![image](https://user-images.githubusercontent.com/45073750/125885486-9f9fce21-8658-4366-ad32-7e882c5a15b4.png)
해당 레포지터리를 implements 해줍니다.  
![image](https://user-images.githubusercontent.com/45073750/125885521-ed68d4bb-6d5a-4401-907e-dfb8a3decd67.png)
그리고 새롭게 만든 인터페이스를 구현하는 클래스를 만들어주고 이곳에서 작업하면 됩니다.  
이곳에 추가하는 메서드는 새롭게 만든 인터페이스에 추가되어야 합니다. ``findCurations()`` 처럼요.  
``setFirstResult()``는 몇 번째 데이터 부터 갖고오냐를 의미하는 것입니다. db 명령어 중 ``offset``에 해당합니다.  
``setMaxResult()``는 ``limit``에 해당합니다. ``offset``과 ``limit``는 jpql 명령어에 없기 때문에 이렇게 추가합니다. Pageable로 처리하는 방법도 있긴합니다.  

쿼리의 select 부분을 보면 ``new com.example.tyfserver.member.dto.CurationsResponse(d.member.nickname, sum(d.amount))``와 같이 있는데 이것은 dto로 바로 반환하기 위한 방법입니다. new 후 패키지명을 작성해주어야 합니다.  
repository에서 엔티티가 아닌 dto를 반환해도 되나? 하고 의문을 가질 수 있고 굉장히 어색해 보일 수 있으나, 실무에서는 엔티티보다는 dto로 반환하는 일이 더 많다고 합니다. (엔티티별 필드가 커지기도 하고 하나의 엔티티가 아닌 여러 엔티티의 한 두개의 필드들이 다양하게 필요한 경우가 많아서 그렇다고 생각함)  

패키지명이 들어가는게 굉장히 보기 싫은데 이 부분은 spring projections나 queryDsl를 사용하면 깔끔하게 처리할 수 있습니다.  
처음에 queryDsl를 사용하려 했던 이유가 쿼리를 2번 호출하고 페치조인을 하겠거니 싶어서 사용하려 했던건데, 쿼리 1번이면 되는걸 깨닫고 사용하지 않았습니다. 그런데 dto 패키지명 까지 써서 더러워진다는걸 생각못해가지고, 다음번 리팩토링 때에 바꿀 예정입니다. queryDsl 사용 시에 gradle 파일에 꽤 추가되는 것이 많기도 해서 리팩토링 작업 때에 수행하면 좋을 것 같다고 생각합니다.  

해당 메서드에 대한 repository 테스트를 간략히 짰는데 ``.containsExactly``로 확인하려 했으나 ``CurationsResponse`` 내부에 equals, hashcode를 정의하는 것이 굉장히 부적절하다고 생각해서 어차피 리스트 크기는 5개니깐 ``.get(n)``로 내부 값을 ``.usingRecursiveComparison()``을 이용해서 비교해줬습니다.  

추가로 궁금한 사항있으면 코멘트로 남겨주세요~~