### PR TITLE
[#83]로그인/회원 가입 리다이렉트 URL을 분리

### DIFF
--- a/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
+++ b/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
@@ -23,13 +23,17 @@ public class Oauth2Controller {
 
     @GetMapping("/login/{oauth}")
     public ResponseEntity<TokenResponse> login(@PathVariable String oauth, @RequestParam String code) {
-        return ResponseEntity.ok(oauth2Service.login(Oauth2Request.generateLoginInfoFrom(oauth), code));
+        return ResponseEntity.ok(
+                oauth2Service.login(Oauth2Request.generateLoginInfoFrom(oauth), code)
+        );
     }
 
     @GetMapping("/signup/ready/{oauth}")
     public ResponseEntity<SignUpReadyResponse> readySignUp(@PathVariable String oauth, @RequestParam String code) {
 
-        return ResponseEntity.ok(oauth2Service.readySignUp(Oauth2Request.generateSignUpInfoFrom(oauth), code));
+        return ResponseEntity.ok(
+                oauth2Service.readySignUp(Oauth2Request.generateSignUpInfoFrom(oauth), code)
+        );
     }
 
     @PostMapping("/signup")

--- a/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
+++ b/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.auth.controller;
 
+import com.example.tyfserver.auth.dto.Oauth2InfoDto;
 import com.example.tyfserver.auth.dto.SignUpResponse;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.auth.exception.SignUpRequestException;
@@ -22,12 +23,13 @@ public class Oauth2Controller {
 
     @GetMapping("/login/{oauth}")
     public ResponseEntity<TokenResponse> login(@PathVariable String oauth, @RequestParam String code) {
-        return ResponseEntity.ok(oauth2Service.login(oauth, code));
+        return ResponseEntity.ok(oauth2Service.login(Oauth2InfoDto.generateLoginInfoFrom(oauth), code));
     }
 
     @GetMapping("/signup/ready/{oauth}")
     public ResponseEntity<SignUpReadyResponse> readySignUp(@PathVariable String oauth, @RequestParam String code) {
-        return ResponseEntity.ok(oauth2Service.readySignUp(oauth, code));
+
+        return ResponseEntity.ok(oauth2Service.readySignUp(Oauth2InfoDto.generateSignUpInfoFrom(oauth), code));
     }
 
     @PostMapping("/signup")

--- a/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
+++ b/server/src/main/java/com/example/tyfserver/auth/controller/Oauth2Controller.java
@@ -1,6 +1,6 @@
 package com.example.tyfserver.auth.controller;
 
-import com.example.tyfserver.auth.dto.Oauth2InfoDto;
+import com.example.tyfserver.auth.dto.Oauth2Request;
 import com.example.tyfserver.auth.dto.SignUpResponse;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.auth.exception.SignUpRequestException;
@@ -23,13 +23,13 @@ public class Oauth2Controller {
 
     @GetMapping("/login/{oauth}")
     public ResponseEntity<TokenResponse> login(@PathVariable String oauth, @RequestParam String code) {
-        return ResponseEntity.ok(oauth2Service.login(Oauth2InfoDto.generateLoginInfoFrom(oauth), code));
+        return ResponseEntity.ok(oauth2Service.login(Oauth2Request.generateLoginInfoFrom(oauth), code));
     }
 
     @GetMapping("/signup/ready/{oauth}")
     public ResponseEntity<SignUpReadyResponse> readySignUp(@PathVariable String oauth, @RequestParam String code) {
 
-        return ResponseEntity.ok(oauth2Service.readySignUp(Oauth2InfoDto.generateSignUpInfoFrom(oauth), code));
+        return ResponseEntity.ok(oauth2Service.readySignUp(Oauth2Request.generateSignUpInfoFrom(oauth), code));
     }
 
     @PostMapping("/signup")

--- a/server/src/main/java/com/example/tyfserver/auth/domain/GoogleOauth2.java
+++ b/server/src/main/java/com/example/tyfserver/auth/domain/GoogleOauth2.java
@@ -16,7 +16,8 @@ public class GoogleOauth2 implements Oauth2 {
     private final String type;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUrl;
+    private final String signUpRedirectUrl;
+    private final String loginRedirectUrl;
     private final String accessTokenApi;
     private final String profileApi;
 

--- a/server/src/main/java/com/example/tyfserver/auth/domain/KakaoOauth2.java
+++ b/server/src/main/java/com/example/tyfserver/auth/domain/KakaoOauth2.java
@@ -15,7 +15,8 @@ public class KakaoOauth2 implements Oauth2 {
     private final String type;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUrl;
+    private final String signUpRedirectUrl;
+    private final String loginRedirectUrl;
     private final String accessTokenApi;
     private final String profileApi;
 

--- a/server/src/main/java/com/example/tyfserver/auth/domain/NaverOauth2.java
+++ b/server/src/main/java/com/example/tyfserver/auth/domain/NaverOauth2.java
@@ -15,7 +15,8 @@ public class NaverOauth2 implements Oauth2 {
     private final String type;
     private final String clientId;
     private final String clientSecret;
-    private final String redirectUrl;
+    private final String signUpRedirectUrl;
+    private final String loginRedirectUrl;
     private final String accessTokenApi;
     private final String profileApi;
 

--- a/server/src/main/java/com/example/tyfserver/auth/domain/Oauth2.java
+++ b/server/src/main/java/com/example/tyfserver/auth/domain/Oauth2.java
@@ -12,7 +12,9 @@ public interface Oauth2 {
 
     String getClientSecret();
 
-    String getRedirectUrl();
+    String getSignUpRedirectUrl();
+
+    String getLoginRedirectUrl();
 
     String getAccessTokenApi();
 

--- a/server/src/main/java/com/example/tyfserver/auth/dto/Oauth2InfoDto.java
+++ b/server/src/main/java/com/example/tyfserver/auth/dto/Oauth2InfoDto.java
@@ -1,0 +1,39 @@
+package com.example.tyfserver.auth.dto;
+
+import com.example.tyfserver.auth.domain.Oauth2;
+import com.example.tyfserver.auth.domain.Oauth2Type;
+import lombok.Getter;
+
+@Getter
+public class Oauth2InfoDto {
+
+    private String type;
+    private String clientId;
+    private String clientSecret;
+    private String redirectUrl;
+    private String accessTokenApi;
+    private String profileApi;
+
+
+    private Oauth2InfoDto(String type, String clientId, String clientSecret, String redirectUrl, String accessTokenApi,
+                         String profileApi) {
+        this.type = type;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUrl = redirectUrl;
+        this.accessTokenApi = accessTokenApi;
+        this.profileApi = profileApi;
+    }
+
+    public static Oauth2InfoDto generateLoginInfoFrom (String oauthType) {
+        Oauth2 oauth = Oauth2Type.findOauth2(oauthType);
+        return new Oauth2InfoDto(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
+                oauth.getLoginRedirectUrl(), oauth.getAccessTokenApi(), oauth.getProfileApi());
+    }
+
+    public static Oauth2InfoDto generateSignUpInfoFrom (String oauthType) {
+        Oauth2 oauth = Oauth2Type.findOauth2(oauthType);
+        return new Oauth2InfoDto(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
+                oauth.getSignUpRedirectUrl(), oauth.getAccessTokenApi(), oauth.getProfileApi());
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/auth/dto/Oauth2Request.java
+++ b/server/src/main/java/com/example/tyfserver/auth/dto/Oauth2Request.java
@@ -5,7 +5,7 @@ import com.example.tyfserver.auth.domain.Oauth2Type;
 import lombok.Getter;
 
 @Getter
-public class Oauth2InfoDto {
+public class Oauth2Request {
 
     private String type;
     private String clientId;
@@ -15,8 +15,8 @@ public class Oauth2InfoDto {
     private String profileApi;
 
 
-    private Oauth2InfoDto(String type, String clientId, String clientSecret, String redirectUrl, String accessTokenApi,
-                         String profileApi) {
+    private Oauth2Request(String type, String clientId, String clientSecret, String redirectUrl, String accessTokenApi,
+                          String profileApi) {
         this.type = type;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
@@ -25,15 +25,15 @@ public class Oauth2InfoDto {
         this.profileApi = profileApi;
     }
 
-    public static Oauth2InfoDto generateLoginInfoFrom (String oauthType) {
+    public static Oauth2Request generateLoginInfoFrom(String oauthType) {
         Oauth2 oauth = Oauth2Type.findOauth2(oauthType);
-        return new Oauth2InfoDto(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
+        return new Oauth2Request(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
                 oauth.getLoginRedirectUrl(), oauth.getAccessTokenApi(), oauth.getProfileApi());
     }
 
-    public static Oauth2InfoDto generateSignUpInfoFrom (String oauthType) {
+    public static Oauth2Request generateSignUpInfoFrom(String oauthType) {
         Oauth2 oauth = Oauth2Type.findOauth2(oauthType);
-        return new Oauth2InfoDto(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
+        return new Oauth2Request(oauth.getType(), oauth.getClientId(), oauth.getClientSecret(),
                 oauth.getSignUpRedirectUrl(), oauth.getAccessTokenApi(), oauth.getProfileApi());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/auth/service/Oauth2Service.java
+++ b/server/src/main/java/com/example/tyfserver/auth/service/Oauth2Service.java
@@ -2,6 +2,7 @@ package com.example.tyfserver.auth.service;
 
 import com.example.tyfserver.auth.domain.Oauth2;
 import com.example.tyfserver.auth.domain.Oauth2Type;
+import com.example.tyfserver.auth.dto.Oauth2InfoDto;
 import com.example.tyfserver.auth.dto.SignUpResponse;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.auth.exception.AlreadyRegisteredException;
@@ -32,22 +33,22 @@ public class Oauth2Service {
     private final MemberRepository memberRepository;
     private final AuthenticationService authenticationService;
 
-    public TokenResponse login(final String oauthType, final String code) {
-        final String email = getEmailFromOauth2(oauthType, code);
+    public TokenResponse login(final Oauth2InfoDto oauth2InfoDto, final String code) {
+        final String email = getEmailFromOauth2(oauth2InfoDto, code);
 
-        Member findMember = memberRepository.findByEmailAndOauth2Type(email, oauthType)
+        Member findMember = memberRepository.findByEmailAndOauth2Type(email, oauth2InfoDto.getType())
                 .orElseThrow(UnregisteredMemberException::new);
 
         return new TokenResponse(authenticationService.createToken(findMember));
     }
 
-    public SignUpReadyResponse readySignUp(final String oauthType, final String code) {
-        final String email = getEmailFromOauth2(oauthType, code);
+    public SignUpReadyResponse readySignUp(final Oauth2InfoDto oauth2InfoDto, final String code) {
+        final String email = getEmailFromOauth2(oauth2InfoDto, code);
 
         memberRepository.findByEmail(email)
-                .ifPresent(member -> validateRegisteredMember(oauthType, member));
+                .ifPresent(member -> validateRegisteredMember(oauth2InfoDto.getType(), member));
 
-        return new SignUpReadyResponse(email, oauthType);
+        return new SignUpReadyResponse(email, oauth2InfoDto.getType());
     }
 
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
@@ -57,29 +58,29 @@ public class Oauth2Service {
         return new SignUpResponse(authenticationService.createToken(persistMember), persistMember.getPageName());
     }
 
-    private String getEmailFromOauth2(String oauthType, String code) {
-        final Oauth2 oauth2 = Oauth2Type.findOauth2(oauthType);
-        final String accessToken = requestAccessToken(code, oauth2);
-        return requestEmail(accessToken, oauth2);
+    private String getEmailFromOauth2(Oauth2InfoDto oauth2InfoDto, String code) {
+        final String accessToken = requestAccessToken(code, oauth2InfoDto);
+        return requestEmail(accessToken, oauth2InfoDto);
     }
 
-    private String requestAccessToken(String code, Oauth2 oauth2) {
+    private String requestAccessToken(String code, Oauth2InfoDto oauth2InfoDto) {
         String body = ApiSender.send(
-                oauth2.getAccessTokenApi(),
+                oauth2InfoDto.getAccessTokenApi(),
                 HttpMethod.POST,
-                generateAccessTokenRequest(code, oauth2)
+                generateAccessTokenRequest(code, oauth2InfoDto)
         );
 
         return extractAccessToken(body);
     }
 
-    private String requestEmail(String accessToken, Oauth2 oauth2) {
+    private String requestEmail(String accessToken, Oauth2InfoDto oauth2InfoDto) {
         String body = ApiSender.send(
-                oauth2.getProfileApi(),
+                oauth2InfoDto.getProfileApi(),
                 HttpMethod.GET,
                 generateProfileRequest(accessToken)
         );
 
+        Oauth2 oauth2 = Oauth2Type.findOauth2(oauth2InfoDto.getType());
         return extractEmail(oauth2, body);
     }
 
@@ -90,17 +91,17 @@ public class Oauth2Service {
         throw new AlreadyRegisteredException(member.getOauth2Type().name());
     }
 
-    private HttpEntity<MultiValueMap<String, String>> generateAccessTokenRequest(String code, Oauth2 oauth2) {
+    private HttpEntity<MultiValueMap<String, String>> generateAccessTokenRequest(String code, Oauth2InfoDto oauth2InfoDto) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
-        params.add("client_id", oauth2.getClientId());
-        params.add("redirect_uri", oauth2.getRedirectUrl());
+        params.add("client_id", oauth2InfoDto.getClientId());
+        params.add("redirect_uri", oauth2InfoDto.getRedirectUrl());
         params.add("code", code);
-        params.add("client_secret", oauth2.getClientSecret());
+        params.add("client_secret", oauth2InfoDto.getClientSecret());
 
         return new HttpEntity<>(params, headers);
     }

--- a/server/src/main/resources/application-oauth2-encrypted.yml
+++ b/server/src/main/resources/application-oauth2-encrypted.yml
@@ -2,7 +2,8 @@ google:
   type: google
   client-id: ENC(2f/CyX/r+1t+8UrDHmopbPug/1b7ia3DWbHr0esB4NtpPXe6Ke73WfrEV7xak7uaYq85H32cMmB46cw4kfj0MRsSeF7g+qCcmALE5ecHKYleUrocB70x3g==)
   client_secret: ENC(1szDbueGfuGBSJlhGcp4wq/e3xgydLacSEAeLxW5Ski29/6Gwaig8A==)
-  redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  signup_redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  login_redirect_url: ENC(C7Pmp7X06UgdQMOKR9aJ0jC6Ndi6izmD+aJnJO3yB22NhLADlYLK9V1RoBH5CQG+)
   access_token_api: https://oauth2.googleapis.com/token
   profile_api: https://www.googleapis.com/oauth2/v2/userinfo
 
@@ -10,7 +11,8 @@ kakao:
   type: kakao
   client_id: ENC(9Uu9p2fXwD9CHp/Z+PbhTzrIJtYVjV+fv3cBRRyo2H7kdPP4aLx7Y5J+RkH08wjG)
   client_secret: ENC(VDoGbTrDbutK2zJbrsFgYlmKotwK8VVJg87ds7U9QnKn2POgfwPXnDP0OrBOmKNZ)
-  redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  signup_redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  login_redirect_url: ENC(egvxtsMCMoVYKjFxAKn/s8lP9AVOAJrd2caswD7FcD0xWpbO5OILi2YOyLGOvgOp)
   access_token_api: https://kauth.kakao.com/oauth/token
   profile_api: https://kapi.kakao.com/v2/user/me
 
@@ -18,6 +20,7 @@ naver:
   type: naver
   client_id: ENC(0+XWlkEBxLGZm6f1m/Y7eAlaMWKGhz5Um6TAbhgbZWg=)
   client_secret: ENC(Tk57HzBY6YMVUMGW/X9NmrToDv+GLgIl)
-  redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  signup_redirect_url: ENC(yUhgBzBS3YCj09FQ0ZuLovXjZ68MLYrkjNPRVQKv6kd/sSSnWpub5ZpilLsuyHnG)
+  login_redirect_url: ENC(Hg3QQURIKHnNc+ZmF15vGIrWWy2KqToPOxJvykjXMRk3fdArFb/Ip8XuBQOdOdw1)
   access_token_api: https://nid.naver.com/oauth2.0/token
   profile_api: https://openapi.naver.com/v1/nid/me

--- a/server/src/main/resources/application-oauth2.yml
+++ b/server/src/main/resources/application-oauth2.yml
@@ -1,7 +1,7 @@
 google:
   type: google
   client-id: google-client-id
-  client_secret: google-client_secret
+  client_secret: google-client-secret
   signup_redirect_url: google-signup-redirect-url
   login_redirect_url: google-login-redirect-url
   access_token_api: https://oauth2.googleapis.com/token
@@ -10,6 +10,7 @@ google:
 kakao:
   type: kakao
   client_id: kakao-client-id
+  client_secret: kakao-client-secret
   signup_redirect_url: kakao-signup-redirect-url
   login_redirect_url: kakao-login-redirect-url
   access_token_api: https://kauth.kakao.com/oauth/token

--- a/server/src/main/resources/application-oauth2.yml
+++ b/server/src/main/resources/application-oauth2.yml
@@ -2,15 +2,16 @@ google:
   type: google
   client-id: google-client-id
   client_secret: google-client_secret
-  redirect_url: google-redirect-url
+  signup_redirect_url: google-signup-redirect-url
+  login_redirect_url: google-login-redirect-url
   access_token_api: https://oauth2.googleapis.com/token
   profile_api: https://www.googleapis.com/oauth2/v2/userinfo
 
 kakao:
   type: kakao
   client_id: kakao-client-id
-  client_secret: kakao-client-secret
-  redirect_url: kakao-redirect-url
+  signup_redirect_url: kakao-signup-redirect-url
+  login_redirect_url: kakao-login-redirect-url
   access_token_api: https://kauth.kakao.com/oauth/token
   profile_api: https://kapi.kakao.com/v2/user/me
 
@@ -18,6 +19,7 @@ naver:
   type: naver
   client_id: naver-client-id
   client_secret: naver-client-secret
-  redirect_url: naver-redirect-url
+  signup_redirect_url: naver-signup-redirect-url
+  login_redirect_url: naver-login-redirect-url
   access_token_api: https://nid.naver.com/oauth2.0/token
   profile_api: https://openapi.naver.com/v1/nid/me


### PR DESCRIPTION
### 변경 사항

login과 signup의 리다이렉트 url 서버 단에서 관리


### 구현 사항
- Oauth2Request 생성
login과 signup은 현재 컨트롤러 단에서 한번 분기가 됨.
그러나 login과 signup의 oauth2 request 메시지를 만드는 부분은 1곳임.
oauth2 request 정보에 관한 부분을 Oauth2Request (dto)로 한번 감쌈.

- 추가 리다이렉트 URL 암호화

