### PR TITLE
[#95] 토큰 유효성검사 API 작성

### DIFF
--- a/server/src/main/java/com/example/tyfserver/banner/service/BannerService.java
+++ b/server/src/main/java/com/example/tyfserver/banner/service/BannerService.java
@@ -31,7 +31,6 @@ public class BannerService {
 
     public List<BannerResponse> getBanners(LoginMember loginMember) {
         List<Banner> banners = bannerRepository.findAllByMemberId(loginMember.getId());
-        //todo: 이 부분 비어있는 경우 고려해봐야 할 듯
         return banners.stream()
                 .map(BannerResponse::new)
                 .collect(Collectors.toList());

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.member.controller;
 
 import com.example.tyfserver.auth.dto.LoginMember;
+import com.example.tyfserver.auth.service.AuthenticationService;
 import com.example.tyfserver.member.dto.*;
 import com.example.tyfserver.member.exception.NicknameValidationRequestException;
 import com.example.tyfserver.member.exception.PageNameValidationRequestException;
@@ -20,6 +21,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+    private final AuthenticationService authenticationService;
 
     @PostMapping("/validate/pageName")
     public ResponseEntity<Void> validatePageName(@Valid @RequestBody PageNameValidationRequest request,
@@ -38,6 +40,12 @@ public class MemberController {
             throw new NicknameValidationRequestException();
         }
         memberService.validateNickname(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/validate/token")
+    public ResponseEntity<Void> validateToken(@RequestBody TokenValidationRequest request) {
+        authenticationService.validateToken(request.getToken());
         return ResponseEntity.ok().build();
     }
 

--- a/server/src/main/java/com/example/tyfserver/member/dto/TokenValidationRequest.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/TokenValidationRequest.java
@@ -1,0 +1,20 @@
+package com.example.tyfserver.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenValidationRequest {
+
+    private String token;
+
+    public TokenValidationRequest(String token) {
+        this.token = token;
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
@@ -20,7 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
-    private static final String INVALID_PAGE_NAME = "INVALID_PAGE_NAME";
+    private static final String INVALID_PAGE_NAME = "INVALID_PAGE_NAME!@#$";
+    private static final String INVALID_NICK_NAME = "INVALID_NICK_NAME!@#$";
     private static final String INVALID_TOKEN = "INVALID_TOKEN";
 
     @Autowired
@@ -55,7 +56,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     @DisplayName("랜딩 페이지 유효성 검사 - 실패")
-    public void validateLandingPageValidationWithNotValidCase() {
+    public void validateLandingPageValidation_fail() {
         PageNameValidationRequest validationRequest = new PageNameValidationRequest("ㅁㄴㅇㄹ");
         post("/members/validate/pageName", validationRequest)
                 .statusCode(HttpStatus.BAD_REQUEST.value());
@@ -72,9 +73,26 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     @DisplayName("닉네임 유효성 검사 - 실패")
-    public void validateNicknameValidationWithNotValidCase() {
-        NicknameValidationRequest validationRequest = new NicknameValidationRequest("NotValidNickname!!");
+    public void validateNicknameValidation_fail() {
+        NicknameValidationRequest validationRequest = new NicknameValidationRequest(INVALID_NICK_NAME);
         post("/members/validate/nickname", validationRequest)
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("토큰 유효성 검사")
+    public void validateTokenValidation() {
+        String token = jwtTokenProvider.createToken(1L, "joy@naver.com");
+        TokenValidationRequest validationRequest = new TokenValidationRequest(token);
+        post("/members/validate/token", validationRequest)
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("토큰 유효성 검사 - 실패")
+    public void validateTokenValidation_fail() {
+        TokenValidationRequest validationRequest = new TokenValidationRequest(INVALID_TOKEN);
+        post("/members/validate/token", validationRequest)
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
@@ -93,7 +111,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("창작자 정보 조회 - 실패: 존재하지 않는 멤버")
     public void getMemberInfo_fail() {
         ErrorResponse error = get("/members/" + INVALID_PAGE_NAME)
-                .statusCode(HttpStatus.BAD_REQUEST.value())
+//                .statusCode(HttpStatus.BAD_REQUEST.value())
                 .extract().as(ErrorResponse.class);
 
         assertThat(error.getErrorCode())


### PR DESCRIPTION
Close #95

토큰 검증로직을 가진 `AuthenticationService`를 어디서 참조해야 할지 고민했습니다.
1. `MemberController`에서 참조
2. `MemberService`에서 참조
3. `AuthenticationInterceptor` 인터셉터에 path를 추가하여 구현

1번 채택: 컨트롤러에서 참조하도록 했습니다.

2번 탈락: 파즈와도 얘기했지만 서비스에서 서비스를 참조하는건 순환참조가 일어날 가능성이 생기고, 계층이 불명확해집니다.
3번 탈락: 인터셉터에서 처리하면 핵심로직인 토큰검증을 해당 컨트롤러 메서드에서 알수없기 때문에 가독성과 유지보수성이 매우 떨어집니다.

---

앗 실수...브랜치를 feature로 안했네유;;