### PR TITLE
창작자  프로필 컴포넌트 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,10 +16,11 @@ import RegisterNamePage from './pages/Register/RegisterName/RegisterNamePage';
 import RegisterSuccessPage from './pages/Register/RegisterSuccess/RegisterSuccessPage';
 import RegisterTermsPage from './pages/Register/RegisterTerms/RegisterTermsPage';
 import StatisticsPage from './pages/Statistics/StatisticsPage';
-import { OAuthProvider } from './types';
+import { CreatorId, OAuthProvider } from './types';
 
 export interface ParamTypes {
-  oauthProvider?: OAuthProvider;
+  oauthProvider: OAuthProvider;
+  creatorId: CreatorId;
 }
 
 const App = () => {

--- a/client/src/components/Creator/Profile/Profile.styles.tsx
+++ b/client/src/components/Creator/Profile/Profile.styles.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import Container from '../../@atom/Container/Container';
 
-export const StyledProfileContainer = styled(Container)``;
+export const ProfileContainer = styled(Container)``;
 
 export const ProfileImg = styled.div`
   width: 8rem;

--- a/client/src/components/Creator/Profile/Profile.tsx
+++ b/client/src/components/Creator/Profile/Profile.tsx
@@ -1,17 +1,22 @@
-import { FC, HTMLAttributes } from 'react';
+import { VFC } from 'react';
 
-import Anchor from '../../@atom/Anchor/Anchor';
 import DefaultUserProfile from '../../../assets/images/defualtUserProfile.png';
-import { NickName, ProfileImg, StyledProfileContainer } from './Profile.styles';
+import { NickName, ProfileImg, ProfileContainer } from './Profile.styles';
+import { useParams } from 'react-router-dom';
+import { ParamTypes } from '../../../App';
+import useCreator from '../../../service/hooks/useCreator';
 
-const Profile: FC<HTMLAttributes<HTMLElement>> = () => {
+const Profile: VFC = () => {
+  const { creatorId } = useParams<ParamTypes>();
+  const { nickname } = useCreator(creatorId);
+
   return (
-    <StyledProfileContainer>
-      <Anchor to="">
+    <ProfileContainer>
+      <a href={window.location.origin + `/creator/${creatorId}`}>
         <ProfileImg style={{ backgroundImage: `url(${DefaultUserProfile})` }}></ProfileImg>
-      </Anchor>
-      <NickName>파노</NickName>
-    </StyledProfileContainer>
+      </a>
+      <NickName>{nickname}</NickName>
+    </ProfileContainer>
   );
 };
 

--- a/client/src/components/Main/CreatorCard/CreatorCard.tsx
+++ b/client/src/components/Main/CreatorCard/CreatorCard.tsx
@@ -10,8 +10,8 @@ export interface CreatorCardProps {
 const CreatorCard: VFC<CreatorCardProps> = ({ creator }) => {
   return (
     <StyledCreatorCard role="creator-card">
-      <ProfileImg src={creator.profileImgSrc} alt={creator.name + '의 프로필 사진'} />
-      <Name>{creator.name}</Name>
+      <ProfileImg src={creator.profileImgSrc} alt={creator.nickname + '의 프로필 사진'} />
+      <Name>{creator.nickname}</Name>
     </StyledCreatorCard>
   );
 };

--- a/client/src/components/Menu/Menu.tsx
+++ b/client/src/components/Menu/Menu.tsx
@@ -22,7 +22,7 @@ const Menu: VFC<MenuProps> = ({ onClose }) => {
   const shareURL = () => {
     if (!userInfo) return;
 
-    donationUrlShare(userInfo.name, userInfo.pageName);
+    donationUrlShare(userInfo.nickname, userInfo.pageName);
   };
 
   return (
@@ -30,7 +30,7 @@ const Menu: VFC<MenuProps> = ({ onClose }) => {
       <ProfileContainer>
         {userInfo ? (
           <>
-            <span>{userInfo.name}</span>
+            <span>{userInfo.nickname}</span>
             <URLCopyButton onClick={shareURL}>후원URL 복사</URLCopyButton>
           </>
         ) : (

--- a/client/src/mock/mockData.ts
+++ b/client/src/mock/mockData.ts
@@ -2,17 +2,42 @@ import whiteBackground from '../assets/images/dummy/profile-img.jpg';
 import { Creator, LoginUserInfo, Statistics } from '../types';
 
 export const creatorListMock: Creator[] = [
-  { name: 'asdf', profileImgSrc: whiteBackground, introduce: '빈칸아님', pageName: 'pageName' },
-  { name: 'asdf', profileImgSrc: whiteBackground, introduce: '', pageName: 'pageName' },
-  { name: 'asdf', profileImgSrc: whiteBackground, introduce: '안녕하세요~', pageName: 'pageName' },
-  { name: 'asdf', profileImgSrc: whiteBackground, introduce: '', pageName: 'pageName' },
+  {
+    nickname: 'asdf',
+    profileImgSrc: whiteBackground,
+    introduce: '빈칸아님',
+    pageName: 'pageName',
+    email: 'jho2301@gmail.com',
+  },
+  {
+    nickname: 'asdf',
+    profileImgSrc: whiteBackground,
+    introduce: '',
+    pageName: 'pageName',
+    email: 'jho2301@gmail.com',
+  },
+  {
+    nickname: 'asdf',
+    profileImgSrc: whiteBackground,
+    introduce: '안녕하세요~',
+    pageName: 'pageName',
+    email: 'jho2301@gmail.com',
+  },
+  {
+    nickname: 'asdf',
+    profileImgSrc: whiteBackground,
+    introduce: '',
+    pageName: 'pageName',
+    email: 'jho2301@gmail.com',
+  },
 ];
 
 export const userInfoMock: LoginUserInfo = {
-  name: 'inch',
+  nickname: 'inch',
   introduce: 'hi',
   pageName: 'inchpage',
   profileImgSrc: 'asdf',
+  email: 'jho2301@gmail.com',
 };
 
 export const statisticsMock: Statistics = {

--- a/client/src/pages/Donation/Donation/DonationPage.tsx
+++ b/client/src/pages/Donation/Donation/DonationPage.tsx
@@ -1,10 +1,10 @@
-import { FC, HTMLAttributes } from 'react';
+import { VFC } from 'react';
 
 import Profile from '../../../components/Creator/Profile/Profile';
 import DonationForm from '../../../components/Donation/DonationForm/DonationForm';
 import { DonationPageTemplate } from './DonationPage.styles';
 
-const DonationPage: FC<HTMLAttributes<HTMLElement>> = () => {
+const DonationPage: VFC = () => {
   return (
     <DonationPageTemplate>
       <section>

--- a/client/src/pages/Donation/Success/DonationSuccessPage.tsx
+++ b/client/src/pages/Donation/Success/DonationSuccessPage.tsx
@@ -1,4 +1,7 @@
 import { VFC } from 'react';
+import { useParams } from 'react-router-dom';
+import { ParamTypes } from '../../../App';
+import useCreator from '../../../service/hooks/useCreator';
 
 import {
   CloseButton,
@@ -12,10 +15,13 @@ import {
 } from './DonationSuccessPage.styles';
 
 const DonationSuccessPage: VFC = () => {
+  const { creatorId } = useParams<ParamTypes>();
+  const { nickname } = useCreator(creatorId);
+
   return (
     <StyledTemplate>
       <SuccessMessageContainer>
-        <SubText>파노님에게</SubText>
+        <SubText>{nickname}님에게</SubText>
         <MainText>3,000원</MainText>
         <SubText>후원되었습니다.</SubText>
         <EmojiText>🎉</EmojiText>

--- a/client/src/pages/Statistics/StatisticsPage.tsx
+++ b/client/src/pages/Statistics/StatisticsPage.tsx
@@ -11,7 +11,7 @@ const StatisticsPage: FC<HTMLAttributes<HTMLElement>> = () => {
   return (
     <StyledTemplate>
       <InfoTitle>
-        {userInfo && userInfo.name}님이
+        {userInfo && userInfo.nickname}님이
         <br />총 후원 받은 금액은
       </InfoTitle>
       <MoneyInfo>

--- a/client/src/service/hooks/useCreator.ts
+++ b/client/src/service/hooks/useCreator.ts
@@ -1,0 +1,11 @@
+import { useRecoilValue } from 'recoil';
+import { CreatorId } from '../../types';
+import { creatorQuery } from '../state/creator';
+
+const useCreator = (creatorId: CreatorId) => {
+  const creator = useRecoilValue(creatorQuery(creatorId));
+
+  return creator;
+};
+
+export default useCreator;

--- a/client/src/service/request/creator.ts
+++ b/client/src/service/request/creator.ts
@@ -1,6 +1,10 @@
-import { Creator } from '../../types';
+import { Creator, CreatorId } from '../../types';
 import { apiClient } from './../../API';
 
 export const requestCreatorList = (): Promise<Creator[]> => {
-  return apiClient.get('creators').then((response) => response.data); // TODO 바꿔야됨
+  return apiClient.get('/curations').then((response) => response.data);
+};
+
+export const requestCreator = (creatorId: CreatorId): Promise<Creator> => {
+  return apiClient.get(`/members/${creatorId}`).then((response) => response.data);
 };

--- a/client/src/service/state/creator.ts
+++ b/client/src/service/state/creator.ts
@@ -1,13 +1,14 @@
-import { selector } from 'recoil';
+import { selector, selectorFamily } from 'recoil';
 
-import { creatorListMock } from './../../mock/mockData';
-import { requestCreatorList } from './../request/creator';
-import { Creator } from './../../types';
+import { requestCreator, requestCreatorList } from './../request/creator';
+import { Creator, CreatorId } from './../../types';
 
 export const creatorListQuery = selector<Creator[]>({
   key: 'creatorListQuery',
-  get: () => {
-    //  return requestCreatorList();
-    return creatorListMock;
-  },
+  get: () => requestCreatorList(),
+});
+
+export const creatorQuery = selectorFamily<Creator, CreatorId>({
+  key: 'creatorQuery',
+  get: (creatorId) => () => requestCreator(creatorId),
 });

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,22 +1,25 @@
 import { OAUTH } from './constants/oauth';
 
+export type CreatorId = string;
+
 export interface Creator {
-  pageName: string;
-  name: string;
+  pageName: CreatorId;
+  nickname: string;
   profileImgSrc: string;
   introduce: string;
+  email: string;
 }
+
 export interface Register {
   email: string;
   nickName: string;
   oauthType: string;
-  urlName: string;
+  urlName: CreatorId;
 }
 
 export interface LoginUserInfo extends Creator {}
 
 export type OAuthProvider = keyof typeof OAUTH;
-
 
 export interface Statistics {
   point: number;


### PR DESCRIPTION
1. Creator타입 사용해야돼 (Register라는 타입이 필요없으.)
2. API호출함수, 리코일 셀렉터패밀리 만들고
3. API문서 확정안났을때 작성한 스키마 다 고쳐놨으
4. 서버에서 pageName으로 주더라도 클라이언트는 creatorId로 써야할듯 추후에 변경될수있으니까