### PR TITLE
[#189]Payment 서비스, 컨트롤러 슬라이싱 테스트

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -249,3 +249,19 @@ include::{snippets}/publicDonations/http-response.adoc[]
 include::{snippets}/publicDonationsMemberNotFoundFailed/http-request.adoc[]
 ==== Response
 include::{snippets}/publicDonationsMemberNotFoundFailed/http-response.adoc[]
+== Payment (결제)
+=== 결제 요청 - 성공
+==== Request
+include::{snippets}/createPayment/http-request.adoc[]
+==== Response
+include::{snippets}/createPayment/http-response.adoc[]
+=== 결제 요청 - 실패 - 회원을 찾을 수 없음
+==== Request
+include::{snippets}/createPaymentMemberNotFoundFailed/http-request.adoc[]
+==== Response
+include::{snippets}/createPaymentMemberNotFoundFailed/http-response.adoc[]
+=== 결제 요청 - 실패 - 유효하지 않은 Request
+==== Request
+include::{snippets}/createPaymentRequestFailed/http-request.adoc[]
+==== Response
+include::{snippets}/createPaymentRequestFailed/http-response.adoc[]

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -204,6 +204,26 @@ include::{snippets}/createDonationMemberNotFoundFailed/http-response.adoc[]
 include::{snippets}/createDonationRequestFailed/http-request.adoc[]
 ==== Response
 include::{snippets}/createDonationRequestFailed/http-response.adoc[]
+=== 후원 요청 - 결제정보 상태가 지불(PAID)가 아님
+==== Request
+include::{snippets}/createDonationFailedStatusNotPaid/http-request.adoc[]
+==== Response
+include::{snippets}/createDonationFailedStatusNotPaid/http-response.adoc[]
+=== 후원 요청 - 결제정보 결제 Id 미일치
+==== Request
+include::{snippets}/createDonationFailedStatusInvalidId/http-request.adoc[]
+==== Response
+include::{snippets}/createDonationFailedStatusInvalidId/http-response.adoc[]
+=== 후원 요청 - 결제정보 결제금액 미일치
+==== Request
+include::{snippets}/createDonationFailedStatusInvalidId/http-request.adoc[]
+==== Response
+include::{snippets}/createDonationFailedStatusInvalidId/http-response.adoc[]
+=== 후원 요청 - 결제정보 유저정보(PageName) 미일치
+==== Request
+include::{snippets}/createDonationFailedInvalidPageName/http-request.adoc[]
+==== Response
+include::{snippets}/createDonationFailedInvalidPageName/http-response.adoc[]
 === 후원 메세지 전송 - 성공
 ==== Request
 include::{snippets}/addDonationMessage/http-request.adoc[]

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
 
     @PutMapping("/profile")
     public ResponseEntity<ProfileResponse> profile(@RequestParam MultipartFile multipartFile, LoginMember loginMember) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(memberService.uploadProfile(multipartFile, loginMember));
+        return ResponseEntity.ok((memberService.uploadProfile(multipartFile, loginMember)));
     }
 
     @DeleteMapping("/profile")

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.findCurations());
     }
 
-    @PostMapping("/profile")
+    @PutMapping("/profile")
     public ResponseEntity<ProfileResponse> profile(@RequestParam MultipartFile multipartFile, LoginMember loginMember) {
         return ResponseEntity.status(HttpStatus.CREATED).body(memberService.uploadProfile(multipartFile, loginMember));
     }

--- a/server/src/main/java/com/example/tyfserver/payment/controller/PaymentController.java
+++ b/server/src/main/java/com/example/tyfserver/payment/controller/PaymentController.java
@@ -2,13 +2,18 @@ package com.example.tyfserver.payment.controller;
 
 import com.example.tyfserver.payment.dto.PaymentSaveRequest;
 import com.example.tyfserver.payment.dto.PaymentSaveResponse;
+import com.example.tyfserver.payment.exception.PaymentRequestException;
+import com.example.tyfserver.payment.exception.PaymentSaveRequestException;
 import com.example.tyfserver.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/payments")
@@ -18,7 +23,12 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping
-    public ResponseEntity<PaymentSaveResponse> payment(@RequestBody PaymentSaveRequest paymentSaveRequest) {
+    public ResponseEntity<PaymentSaveResponse> payment(@Valid @RequestBody PaymentSaveRequest paymentSaveRequest, BindingResult result) {
+
+        if (result.hasErrors()) {
+            throw new PaymentSaveRequestException();
+        }
+
         PaymentSaveResponse response = paymentService.createPayment(paymentSaveRequest);
         return ResponseEntity.ok(response);
     }

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.payment.domain;
 
 import com.example.tyfserver.common.domain.BaseTimeEntity;
+import com.example.tyfserver.payment.exception.IllegalPaymentInfoException;
 import com.example.tyfserver.payment.exception.PaymentRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -56,7 +57,7 @@ public class Payment extends BaseTimeEntity {
     private void validatePaymentComplete(PaymentInfo paymentInfo) {
         if (!PaymentStatus.isPaid(paymentInfo.getStatus())) {
             updateStatus(paymentInfo.getStatus());
-            throw new PaymentRequestException(ERROR_CODE_NOT_PAID);
+            throw IllegalPaymentInfoException.from(IllegalPaymentInfoException.ERROR_CODE_NOT_PAID, paymentInfo.getModule());
         }
 
         validatePaymentInfo(paymentInfo);
@@ -65,17 +66,17 @@ public class Payment extends BaseTimeEntity {
     private void validatePaymentInfo(PaymentInfo paymentInfo) {
         if (!id.equals(paymentInfo.getMerchantId())) {
             updateStatus(PaymentStatus.INVALID);
-            throw new PaymentRequestException(ERROR_CODE_INVALID_MERCHANT_ID);
+            throw IllegalPaymentInfoException.from(ERROR_CODE_INVALID_MERCHANT_ID, paymentInfo.getModule());
         }
 
         if (!amount.equals(paymentInfo.getAmount())) {
             updateStatus(PaymentStatus.INVALID);
-            throw new PaymentRequestException(ERROR_CODE_INVALID_AMOUNT);
+            throw IllegalPaymentInfoException.from(ERROR_CODE_INVALID_AMOUNT, paymentInfo.getModule());
         }
 
         if (!pageName.equals(paymentInfo.getPageName())) {
             updateStatus(PaymentStatus.INVALID);
-            throw new PaymentRequestException(ERROR_INVALID_CREATOR);
+            throw IllegalPaymentInfoException.from(ERROR_INVALID_CREATOR, paymentInfo.getModule());
         }
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/domain/PaymentInfo.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/PaymentInfo.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.payment.domain;
 
+import com.example.tyfserver.payment.util.IamPortPaymentServiceConnector;
 import lombok.Getter;
 
 @Getter
@@ -9,12 +10,14 @@ public class PaymentInfo {
     private Long amount;
     private String pageName;
     private String impUid;
+    private String module;
 
-    public PaymentInfo(Long merchantId, PaymentStatus status, Long amount, String pageName, String impUid) {
+    public PaymentInfo(Long merchantId, PaymentStatus status, Long amount, String pageName, String impUid, String module) {
         this.merchantId = merchantId;
         this.status = status;
         this.amount = amount;
         this.pageName = pageName;
         this.impUid = impUid;
+        this.module = module;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/dto/PaymentSaveRequest.java
+++ b/server/src/main/java/com/example/tyfserver/payment/dto/PaymentSaveRequest.java
@@ -4,14 +4,22 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentSaveRequest {
 
+    @NotNull
     private Long amount;
 
+    @NotBlank
+    @Email
     private String email;
 
+    @NotBlank
     private String pageName;
 
     public PaymentSaveRequest(Long amount, String email, String pageName) {

--- a/server/src/main/java/com/example/tyfserver/payment/exception/IllegalPaymentInfoException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/IllegalPaymentInfoException.java
@@ -1,0 +1,43 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class IllegalPaymentInfoException extends BaseException {
+    public static final String ERROR_CODE_NOT_PAID = "payment-002";
+    private static final String MESSAGE_NOT_PAID = "결제가 완료되지 않았습니다.";
+
+    public static final String ERROR_CODE_INVALID_MERCHANT_ID = "payment-003";
+    private static final String MESSAGE_INVALID_MERCHANT_ID = "결제 정보의 Merchant ID가 일치하지 않습니다.";
+
+    public static final String ERROR_CODE_INVALID_AMOUNT = "payment-004";
+    private static final String MESSAGE_INVALID_AMOUNT = "결제 정보의 Amount가 일치하지 않습니다.";
+
+    public static final String ERROR_INVALID_CREATOR = "payment-005";
+    private static final String MESSAGE_INVALID_CREATOR = "결제 정보의 PageName(상품정보)가 일치하지 않습니다.";
+
+    private static final String MESSAGE_INVALID_ERROR_CODE = "적절하지 않은 IllegalPaymentInfoException ErrorCode 입니다.";
+
+    private IllegalPaymentInfoException(String code, String message) {
+        super(code,  message);
+    }
+
+    public static IllegalPaymentInfoException from(String code, String module) {
+        if (ERROR_CODE_NOT_PAID.equals(code)) {
+            return new IllegalPaymentInfoException(code, module + MESSAGE_NOT_PAID);
+        }
+
+        if (ERROR_CODE_INVALID_MERCHANT_ID.equals(code)) {
+            return new IllegalPaymentInfoException(code, module + MESSAGE_INVALID_MERCHANT_ID);
+        }
+
+        if (ERROR_CODE_INVALID_AMOUNT.equals(code)) {
+            return new IllegalPaymentInfoException(code, module + MESSAGE_INVALID_AMOUNT);
+        }
+
+        if (ERROR_INVALID_CREATOR.equals(code)) {
+            return new IllegalPaymentInfoException(code, module + MESSAGE_INVALID_CREATOR);
+        }
+
+        throw new RuntimeException(MESSAGE_INVALID_ERROR_CODE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/exception/PaymentRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/PaymentRequestException.java
@@ -4,10 +4,10 @@ import com.example.tyfserver.common.exception.BaseException;
 
 public class PaymentRequestException extends BaseException {
 
-    public static final String ERROR_CODE_NOT_PAID = "payment-001";
-    public static final String ERROR_CODE_INVALID_MERCHANT_ID = "payment-002";
-    public static final String ERROR_CODE_INVALID_AMOUNT = "payment-003";
-    public static final String ERROR_INVALID_CREATOR = "payment-004";
+    public static final String ERROR_CODE_NOT_PAID = "payment-002";
+    public static final String ERROR_CODE_INVALID_MERCHANT_ID = "payment-003";
+    public static final String ERROR_CODE_INVALID_AMOUNT = "payment-004";
+    public static final String ERROR_INVALID_CREATOR = "payment-005";
     private static final String MESSAGE = "결제 요청 데이터 유효하지 않음";
 
     public PaymentRequestException(String code) {

--- a/server/src/main/java/com/example/tyfserver/payment/exception/PaymentSaveRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/PaymentSaveRequestException.java
@@ -1,0 +1,13 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class PaymentSaveRequestException extends BaseException {
+
+    public static final String ERROR_CODE = "payment-001";
+    private static final String MESSAGE = "결제정보 생성 시에 넘기는 Request의 값이 유효한 값이 아닙니다.";
+
+    public PaymentSaveRequestException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -29,9 +29,7 @@ public class PaymentService {
 
         Payment payment = new Payment(saveRequest.getAmount(), saveRequest.getEmail(),
                 creator.getPageName());
-        Payment savedPayment = paymentRepository.save(payment);
-
-        return new PaymentSaveResponse(savedPayment);
+        return new PaymentSaveResponse(paymentRepository.save(payment));
     }
 
     public Payment completePayment(PaymentRequest paymentRequest) {

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -29,10 +29,9 @@ public class PaymentService {
 
         Payment payment = new Payment(saveRequest.getAmount(), saveRequest.getEmail(),
                 creator.getPageName());
-        paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
 
-        return new PaymentSaveResponse(payment);
-        // todo: PaymentSaveResponse에 어떤 필드값들이 있으면 좋을까? (일단은 정말 필요한 값인 merchantUid만 추가!)
+        return new PaymentSaveResponse(savedPayment);
     }
 
     public Payment completePayment(PaymentRequest paymentRequest) {

--- a/server/src/main/java/com/example/tyfserver/payment/util/IamPortPaymentServiceConnector.java
+++ b/server/src/main/java/com/example/tyfserver/payment/util/IamPortPaymentServiceConnector.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class IamPortPaymentServiceConnector implements PaymentServiceConnector {
-    private static final String moduleName = "아임포트";
+    private static final String MODULE_NAME = "아임포트";
     private static final String IAMPORT_API_URL = "https://api.iamport.kr";
 
     @Value("${iamport.rest_api_key}")
@@ -34,7 +34,7 @@ public class IamPortPaymentServiceConnector implements PaymentServiceConnector {
                 Long.parseLong(response.getAmount()),
                 response.getName(),
                 response.getImp_uid(),
-                moduleName);
+                MODULE_NAME);
     }
 
     private IamPortPaymentInfo request(PaymentRequest paymentRequest) {

--- a/server/src/main/java/com/example/tyfserver/payment/util/IamPortPaymentServiceConnector.java
+++ b/server/src/main/java/com/example/tyfserver/payment/util/IamPortPaymentServiceConnector.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class IamPortPaymentServiceConnector implements PaymentServiceConnector {
+    private static final String moduleName = "아임포트";
     private static final String IAMPORT_API_URL = "https://api.iamport.kr";
 
     @Value("${iamport.rest_api_key}")
@@ -32,7 +33,8 @@ public class IamPortPaymentServiceConnector implements PaymentServiceConnector {
                 PaymentStatus.valueOf(response.getStatus().toUpperCase()),
                 Long.parseLong(response.getAmount()),
                 response.getName(),
-                response.getImp_uid());
+                response.getImp_uid(),
+                moduleName);
     }
 
     private IamPortPaymentInfo request(PaymentRequest paymentRequest) {

--- a/server/src/test/java/com/example/tyfserver/banner/controller/BannerControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/banner/controller/BannerControllerTest.java
@@ -44,9 +44,9 @@ class BannerControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
     @MockBean
-    AuthenticationArgumentResolver authenticationArgumentResolver;
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
     @MockBean
-    AuthenticationInterceptor authenticationInterceptor;
+    private AuthenticationInterceptor authenticationInterceptor;
     @MockBean
     private BannerService bannerService;
 

--- a/server/src/test/java/com/example/tyfserver/donation/controller/DonationControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/controller/DonationControllerTest.java
@@ -47,9 +47,9 @@ class DonationControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    AuthenticationArgumentResolver authenticationArgumentResolver;
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
     @MockBean
-    AuthenticationInterceptor authenticationInterceptor;
+    private AuthenticationInterceptor authenticationInterceptor;
     @MockBean
     private DonationService donationService;
 

--- a/server/src/test/java/com/example/tyfserver/donation/controller/DonationControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/controller/DonationControllerTest.java
@@ -13,6 +13,7 @@ import com.example.tyfserver.donation.exception.DonationRequestException;
 import com.example.tyfserver.donation.service.DonationService;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.example.tyfserver.payment.dto.PaymentRequest;
+import com.example.tyfserver.payment.exception.IllegalPaymentInfoException;
 import com.example.tyfserver.payment.exception.PaymentRequestException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -120,7 +121,7 @@ class DonationControllerTest {
         //given
         DonationRequest request = new DonationRequest("impuid", 1L);
         //when
-        doThrow(new PaymentRequestException(PaymentRequestException.ERROR_CODE_NOT_PAID))
+        doThrow(IllegalPaymentInfoException.from(IllegalPaymentInfoException.ERROR_CODE_NOT_PAID, "테스트모듈"))
                 .when(donationService).createDonation(Mockito.any(PaymentRequest.class));
 
         //then
@@ -128,7 +129,7 @@ class DonationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("errorCode").value(PaymentRequestException.ERROR_CODE_NOT_PAID))
+                .andExpect(jsonPath("errorCode").value(IllegalPaymentInfoException.ERROR_CODE_NOT_PAID))
                 .andDo(document("createDonationFailedStatusNotPaid",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())))
@@ -141,7 +142,7 @@ class DonationControllerTest {
         //given
         DonationRequest request = new DonationRequest("impuid", 1L);
         //when
-        doThrow(new PaymentRequestException(PaymentRequestException.ERROR_CODE_INVALID_MERCHANT_ID))
+        doThrow(new PaymentRequestException(IllegalPaymentInfoException.ERROR_CODE_INVALID_MERCHANT_ID))
                 .when(donationService).createDonation(Mockito.any(PaymentRequest.class));
 
         //then
@@ -149,7 +150,7 @@ class DonationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("errorCode").value(PaymentRequestException.ERROR_CODE_INVALID_MERCHANT_ID))
+                .andExpect(jsonPath("errorCode").value(IllegalPaymentInfoException.ERROR_CODE_INVALID_MERCHANT_ID))
                 .andDo(document("createDonationFailedStatusInvalidId",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())))
@@ -162,7 +163,7 @@ class DonationControllerTest {
         //given
         DonationRequest request = new DonationRequest("impuid", 1L);
         //when
-        doThrow(new PaymentRequestException(PaymentRequestException.ERROR_CODE_INVALID_AMOUNT))
+        doThrow(new PaymentRequestException(IllegalPaymentInfoException.ERROR_CODE_INVALID_AMOUNT))
                 .when(donationService).createDonation(Mockito.any(PaymentRequest.class));
 
         //then
@@ -170,7 +171,7 @@ class DonationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("errorCode").value(PaymentRequestException.ERROR_CODE_INVALID_AMOUNT))
+                .andExpect(jsonPath("errorCode").value(IllegalPaymentInfoException.ERROR_CODE_INVALID_AMOUNT))
                 .andDo(document("createDonationFailedInvalidAmount",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())))
@@ -183,7 +184,7 @@ class DonationControllerTest {
         //given
         DonationRequest request = new DonationRequest("impuid", 1L);
         //when
-        doThrow(new PaymentRequestException(PaymentRequestException.ERROR_INVALID_CREATOR))
+        doThrow(new PaymentRequestException(IllegalPaymentInfoException.ERROR_INVALID_CREATOR))
                 .when(donationService).createDonation(Mockito.any(PaymentRequest.class));
 
         //then
@@ -191,7 +192,7 @@ class DonationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("errorCode").value(PaymentRequestException.ERROR_INVALID_CREATOR))
+                .andExpect(jsonPath("errorCode").value(IllegalPaymentInfoException.ERROR_INVALID_CREATOR))
                 .andDo(document("createDonationFailedInvalidPageName",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint())))

--- a/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
@@ -56,7 +56,7 @@ public class PaymentControllerTest {
         when(paymentService.createPayment(any(PaymentSaveRequest.class))).thenReturn(
                 paymentSaveResponse
         );
-        
+
         //then
         mockMvc.perform(post("/payments")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
@@ -53,9 +53,10 @@ public class PaymentControllerTest {
 
 
         //when
-        when(paymentService.createPayment(any(PaymentSaveRequest.class))).thenReturn(
-                paymentSaveResponse
-        );
+        when(paymentService.createPayment(any(PaymentSaveRequest.class)))
+                .thenReturn(
+                        paymentSaveResponse
+                );
 
         //then
         mockMvc.perform(post("/payments")

--- a/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
@@ -36,12 +36,12 @@ public class PaymentControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    PaymentService paymentService;
+    private PaymentService paymentService;
 
     @MockBean
-    AuthenticationArgumentResolver authenticationArgumentResolver;
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
     @MockBean
-    AuthenticationInterceptor authenticationInterceptor;
+    private AuthenticationInterceptor authenticationInterceptor;
 
     @Test
     @DisplayName("/payments - success")

--- a/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,112 @@
+package com.example.tyfserver.payment.controller;
+
+import com.example.tyfserver.auth.config.AuthenticationArgumentResolver;
+import com.example.tyfserver.auth.config.AuthenticationInterceptor;
+import com.example.tyfserver.member.exception.MemberNotFoundException;
+import com.example.tyfserver.payment.domain.Payment;
+import com.example.tyfserver.payment.dto.PaymentSaveRequest;
+import com.example.tyfserver.payment.dto.PaymentSaveResponse;
+import com.example.tyfserver.payment.exception.PaymentSaveRequestException;
+import com.example.tyfserver.payment.service.PaymentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PaymentController.class)
+@AutoConfigureRestDocs
+public class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    PaymentService paymentService;
+
+    @MockBean
+    AuthenticationArgumentResolver authenticationArgumentResolver;
+    @MockBean
+    AuthenticationInterceptor authenticationInterceptor;
+
+    @Test
+    @DisplayName("/payments - success")
+    public void createPayment() throws Exception {
+        //given
+        PaymentSaveRequest paymentSaveRequest = new PaymentSaveRequest(1000L, "test@test.com", "test");
+        PaymentSaveResponse paymentSaveResponse = new PaymentSaveResponse(new Payment(1L, paymentSaveRequest.getAmount(),
+                paymentSaveRequest.getEmail(), paymentSaveRequest.getPageName()));
+
+
+        //when
+        when(paymentService.createPayment(any(PaymentSaveRequest.class))).thenReturn(
+                paymentSaveResponse
+        );
+        
+        //then
+        mockMvc.perform(post("/payments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(paymentSaveRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("merchantUid").value(1L))
+                .andDo(document("createPayment",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+
+    @Test
+    @DisplayName("/payments - 회원을 찾을 수 없음")
+    public void createPaymentMemberNotFoundFailed() throws Exception {
+        //given
+        PaymentSaveRequest paymentSaveRequest = new PaymentSaveRequest(1000L, "test@test.com", "test");
+
+        //when
+        doThrow(new MemberNotFoundException()).when(paymentService).createPayment(any(PaymentSaveRequest.class));
+
+        //then
+        mockMvc.perform(post("/payments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(paymentSaveRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value(MemberNotFoundException.ERROR_CODE))
+                .andDo(document("createPaymentMemberNotFoundFailed",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+
+
+    @Test
+    @DisplayName("/payments - 유효하지 않은 Request")
+    public void createPaymentRequestFailed() throws Exception {
+        //given
+        PaymentSaveRequest paymentSaveRequest = new PaymentSaveRequest(1000L, "  ", "test");
+
+        //when
+        //then
+        mockMvc.perform(post("/payments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(paymentSaveRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value(PaymentSaveRequestException.ERROR_CODE))
+                .andDo(document("createPaymentRequestFailed",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/payment/domain/PaymentTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/domain/PaymentTest.java
@@ -13,7 +13,8 @@ class PaymentTest {
     @DisplayName("결제 정보 유효성 검사 통과 시, 결제가 완료된다.")
     void testComplete() {
         //given
-        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 1000L, "test", "test");
+        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 1000L,
+                "test", "test", "테스트모듈");
         Payment payment = new Payment(1L,1000L, "test@test.com", "test");
 
         //when
@@ -27,7 +28,8 @@ class PaymentTest {
     @Test
     void testCompleteNotPaid() {
         //given
-        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.CANCELLED, 1000L, "test", "test");
+        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.CANCELLED, 1000L,
+                "test", "test", "테스트모듈");
         Payment payment = new Payment(1L,1000L, "test@test.com", "test");
 
         //when
@@ -43,7 +45,8 @@ class PaymentTest {
     @Test
     void testCompleteWhenIdDiff() {
         //given
-        PaymentInfo paymentInfo = new PaymentInfo(2L, PaymentStatus.PAID, 1000L, "test", "test");
+        PaymentInfo paymentInfo = new PaymentInfo(2L, PaymentStatus.PAID, 1000L,
+                "test", "test", "테스트모듈");
         Payment payment = new Payment(1L,1000L, "test@test.com", "test");
 
         //when
@@ -59,7 +62,8 @@ class PaymentTest {
     @Test
     void testCompleteWhenAmountDiff() {
         //given
-        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 10000000L, "test", "test");
+        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 10000000L,
+                "test", "test", "테스트모듈");
         Payment payment = new Payment(1L,1000L, "test@test.com", "test");
 
         //when
@@ -75,7 +79,8 @@ class PaymentTest {
     @Test
     void testCompleteWhenPageNameDiff() {
         //given
-        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 1000L, "fake", "test");
+        PaymentInfo paymentInfo = new PaymentInfo(1L, PaymentStatus.PAID, 1000L,
+                "fake", "test", "테스트모듈");
         Payment payment = new Payment(1L,1000L, "test@test.com", "test");
 
         //when

--- a/server/src/test/java/com/example/tyfserver/payment/service/PaymentServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/service/PaymentServiceTest.java
@@ -1,0 +1,175 @@
+package com.example.tyfserver.payment.service;
+
+import com.example.tyfserver.member.domain.MemberTest;
+import com.example.tyfserver.member.repository.MemberRepository;
+import com.example.tyfserver.payment.domain.Payment;
+import com.example.tyfserver.payment.domain.PaymentInfo;
+import com.example.tyfserver.payment.domain.PaymentServiceConnector;
+import com.example.tyfserver.payment.domain.PaymentStatus;
+import com.example.tyfserver.payment.dto.PaymentRequest;
+import com.example.tyfserver.payment.dto.PaymentSaveRequest;
+import com.example.tyfserver.payment.dto.PaymentSaveResponse;
+import com.example.tyfserver.payment.exception.PaymentRequestException;
+import com.example.tyfserver.payment.repository.PaymentRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PaymentServiceConnector paymentServiceConnector;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @DisplayName("결제정보를 생성한다.")
+    @Test
+    void createPayment() {
+        //given
+        PaymentSaveRequest paymentSaveRequest = new PaymentSaveRequest(1000L, "test@test.com", "pagename");
+        when(memberRepository.findByPageName(Mockito.anyString()))
+                .thenReturn(
+                        Optional.of(MemberTest.testMember()));
+
+        when(paymentRepository.save(Mockito.any(Payment.class)))
+                .thenReturn(
+                        new Payment(1L, paymentSaveRequest.getAmount(), paymentSaveRequest.getEmail(), paymentSaveRequest.getPageName()));
+
+        //when
+        PaymentSaveResponse paymentSaveResponse = paymentService.createPayment(paymentSaveRequest);
+
+        //then
+        Assertions.assertThat(paymentSaveResponse.getMerchantUid()).isEqualTo(1L);
+    }
+
+
+    @DisplayName("결제정보 승인이 완료된다.")
+    @Test
+    void completePayment() {
+        //given
+        PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
+        when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
+                .thenReturn(new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
+                        "pagename",  paymentRequest.getImpUid()));
+
+        when(paymentRepository.findById(anyLong()))
+                .thenReturn(
+                        Optional.of(new Payment(paymentRequest.getMerchantUid(), 1000L, "test@test.com", "pagename")));
+
+        //then
+        Payment payment = paymentService.completePayment(paymentRequest);
+        Assertions.assertThat(payment.getImpUid()).isEqualTo(paymentRequest.getImpUid());
+        Assertions.assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+    }
+
+    @DisplayName("결제상태가 지불(PAID)이 아닌 결제정보가 전달되면 승인이 실패 한다.")
+    @Test
+    void failCompletePaymentNotPaid() {
+        //given
+        PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
+        PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.CANCELLED, 1000L,
+                "pageName", paymentRequest.getImpUid());
+
+        when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
+                .thenReturn(paymentInfo);
+
+        when(paymentRepository.findById(anyLong()))
+                .thenReturn(
+                        Optional.of(new Payment(paymentRequest.getMerchantUid(), 1000L,
+                                "test@test.com", paymentInfo.getPageName())));
+
+        //then
+        Assertions.assertThatThrownBy(() -> {
+             paymentService.completePayment(paymentRequest);
+        }).isInstanceOf(PaymentRequestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_NOT_PAID);
+    }
+
+    @DisplayName("저장된 결제 ID와 외부 전달받은 결제 정보 ID가 다를 경우 결제승인 실패한다.")
+    @Test
+    void failCompletePaymentInvalidMerchantId() {
+        //given
+        PaymentRequest paymentRequest = new PaymentRequest("impuid", 12345L);
+        PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
+                "pageName", paymentRequest.getImpUid());
+
+        when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
+                .thenReturn(paymentInfo);
+
+        when(paymentRepository.findById(anyLong()))
+                .thenReturn(
+                        Optional.of(new Payment(1L, 1000L,
+                                "test@test.com", paymentInfo.getPageName())));
+
+        //then
+        Assertions.assertThatThrownBy(() -> {
+            paymentService.completePayment(paymentRequest);
+        }).isInstanceOf(PaymentRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_INVALID_MERCHANT_ID);
+    }
+
+
+    @DisplayName("저장된 결제 금액과 외부 결제모듈의 결제 금액 정보가 다를 경우 결제승인 실패한다.")
+    @Test
+    void failCompletePaymentInvalidAmount() {
+        //given
+        PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
+        PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1_000_000L,
+                "pageName", paymentRequest.getImpUid());
+
+        when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
+                .thenReturn(paymentInfo);
+
+        when(paymentRepository.findById(anyLong()))
+                .thenReturn(
+                        Optional.of(new Payment(paymentRequest.getMerchantUid(), 1000L,
+                                "test@test.com", paymentInfo.getPageName())));
+
+        //then
+        Assertions.assertThatThrownBy(() -> {
+            paymentService.completePayment(paymentRequest);
+        }).isInstanceOf(PaymentRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_INVALID_AMOUNT);
+    }
+
+    @DisplayName("저장된 결제 PageName 정보와 전달받 PageName 정보가 다를 경우 결제승인 실패한다.")
+    @Test
+    void failCompletePaymentInvalidPageName() {
+        //given
+        PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
+        PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
+                "pageName", paymentRequest.getImpUid());
+
+        when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
+                .thenReturn(paymentInfo);
+
+        when(paymentRepository.findById(anyLong()))
+                .thenReturn(
+                        Optional.of(new Payment(paymentRequest.getMerchantUid(), 1000L,
+                                "test@test.com", "diffPageName")));
+
+        //then
+        Assertions.assertThatThrownBy(() -> {
+            paymentService.completePayment(paymentRequest);
+        }).isInstanceOf(PaymentRequestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_INVALID_CREATOR);
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/payment/service/PaymentServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/payment/service/PaymentServiceTest.java
@@ -9,6 +9,7 @@ import com.example.tyfserver.payment.domain.PaymentStatus;
 import com.example.tyfserver.payment.dto.PaymentRequest;
 import com.example.tyfserver.payment.dto.PaymentSaveRequest;
 import com.example.tyfserver.payment.dto.PaymentSaveResponse;
+import com.example.tyfserver.payment.exception.IllegalPaymentInfoException;
 import com.example.tyfserver.payment.exception.PaymentRequestException;
 import com.example.tyfserver.payment.repository.PaymentRepository;
 import org.assertj.core.api.Assertions;
@@ -68,7 +69,7 @@ class PaymentServiceTest {
         PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
         when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
                 .thenReturn(new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
-                        "pagename",  paymentRequest.getImpUid()));
+                        "pagename",  paymentRequest.getImpUid(), "테스트모듈"));
 
         when(paymentRepository.findById(anyLong()))
                 .thenReturn(
@@ -86,7 +87,7 @@ class PaymentServiceTest {
         //given
         PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
         PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.CANCELLED, 1000L,
-                "pageName", paymentRequest.getImpUid());
+                "pageName", paymentRequest.getImpUid(), "테스트모듈");
 
         when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
                 .thenReturn(paymentInfo);
@@ -99,8 +100,8 @@ class PaymentServiceTest {
         //then
         Assertions.assertThatThrownBy(() -> {
              paymentService.completePayment(paymentRequest);
-        }).isInstanceOf(PaymentRequestException.class)
-        .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_NOT_PAID);
+        }).isInstanceOf(IllegalPaymentInfoException.class)
+        .hasFieldOrPropertyWithValue("errorCode", IllegalPaymentInfoException.ERROR_CODE_NOT_PAID);
     }
 
     @DisplayName("저장된 결제 ID와 외부 전달받은 결제 정보 ID가 다를 경우 결제승인 실패한다.")
@@ -109,7 +110,7 @@ class PaymentServiceTest {
         //given
         PaymentRequest paymentRequest = new PaymentRequest("impuid", 12345L);
         PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
-                "pageName", paymentRequest.getImpUid());
+                "pageName", paymentRequest.getImpUid(), "테스트모듈");
 
         when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
                 .thenReturn(paymentInfo);
@@ -122,8 +123,8 @@ class PaymentServiceTest {
         //then
         Assertions.assertThatThrownBy(() -> {
             paymentService.completePayment(paymentRequest);
-        }).isInstanceOf(PaymentRequestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_INVALID_MERCHANT_ID);
+        }).isInstanceOf(IllegalPaymentInfoException.class)
+                .hasFieldOrPropertyWithValue("errorCode", IllegalPaymentInfoException.ERROR_CODE_INVALID_MERCHANT_ID);
     }
 
 
@@ -133,7 +134,7 @@ class PaymentServiceTest {
         //given
         PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
         PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1_000_000L,
-                "pageName", paymentRequest.getImpUid());
+                "pageName", paymentRequest.getImpUid(), "테스트모듈");
 
         when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
                 .thenReturn(paymentInfo);
@@ -146,8 +147,8 @@ class PaymentServiceTest {
         //then
         Assertions.assertThatThrownBy(() -> {
             paymentService.completePayment(paymentRequest);
-        }).isInstanceOf(PaymentRequestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_CODE_INVALID_AMOUNT);
+        }).isInstanceOf(IllegalPaymentInfoException.class)
+                .hasFieldOrPropertyWithValue("errorCode", IllegalPaymentInfoException.ERROR_CODE_INVALID_AMOUNT);
     }
 
     @DisplayName("저장된 결제 PageName 정보와 전달받 PageName 정보가 다를 경우 결제승인 실패한다.")
@@ -156,7 +157,7 @@ class PaymentServiceTest {
         //given
         PaymentRequest paymentRequest = new PaymentRequest("impuid", 1L);
         PaymentInfo paymentInfo = new PaymentInfo(paymentRequest.getMerchantUid(), PaymentStatus.PAID, 1000L,
-                "pageName", paymentRequest.getImpUid());
+                "pageName", paymentRequest.getImpUid(), "테스트모듈");
 
         when(paymentServiceConnector.requestPaymentInfo(Mockito.any(PaymentRequest.class)))
                 .thenReturn(paymentInfo);
@@ -169,7 +170,7 @@ class PaymentServiceTest {
         //then
         Assertions.assertThatThrownBy(() -> {
             paymentService.completePayment(paymentRequest);
-        }).isInstanceOf(PaymentRequestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", PaymentRequestException.ERROR_INVALID_CREATOR);
+        }).isInstanceOf(IllegalPaymentInfoException.class)
+                .hasFieldOrPropertyWithValue("errorCode", IllegalPaymentInfoException.ERROR_INVALID_CREATOR);
     }
 }


### PR DESCRIPTION
### 추가사항
- Payment에 대한 서비스, 컨트롤러 슬라이싱 테스트 추가
- Payment 추가된 API RestDocs 작성
- 변경된 도네이션 로직에 따른 예외 사항 추가
  - 실 결제정보가 PAID가 아닐경우
  - 실 결제정보와 저장된 결제정보 Id 미일치
  - 실 결제정보와 저장된 결제정보 amount 미일치
  - 실 결제정보와 저장된 결제정보 pageName 미일치