### PR TITLE
[#223] 회원 자신의 후원메세지 유효하지 않은 토큰시 처리 플로우

### DIFF
--- a/client/src/constants/error.ts
+++ b/client/src/constants/error.ts
@@ -1,9 +1,11 @@
 export enum AUTH_ERROR {
+  INVALID_TOKEN = 'auth-002',
   ALREADY_REGISTER = 'auth-004',
   NOT_USER = 'auth-006',
 }
 
 export const AUTH_ERROR_MESSAGE = {
+  [AUTH_ERROR.INVALID_TOKEN]: '유효하지 않은 토큰입니다,',
   [AUTH_ERROR.ALREADY_REGISTER]: '이미 가입되어 있는 사용자입니다.',
   [AUTH_ERROR.NOT_USER]: '유저가 아닙니다.',
 } as const;

--- a/client/src/service/hooks/useDonationMessageList.ts
+++ b/client/src/service/hooks/useDonationMessageList.ts
@@ -7,6 +7,7 @@ import {
   requestCreatorPublicDonationList,
 } from '../request/creator';
 import useAccessToken from './useAccessToken';
+import { AUTH_ERROR } from '../../constants/error';
 
 const useDonationMessageList = (isAdmin: boolean, creatorId: CreatorId) => {
   const [donationList, setDonationList] = useState<Donation[]>([]);
@@ -15,7 +16,17 @@ const useDonationMessageList = (isAdmin: boolean, creatorId: CreatorId) => {
   const { accessToken } = useAccessToken();
 
   const initDonationList = async () => {
-    if (isAdmin) return showMoreDonationList();
+    if (isAdmin) {
+      try {
+        return showMoreDonationList();
+      } catch (error) {
+        const { errorCode } = error.response.data;
+        if (errorCode === AUTH_ERROR.INVALID_TOKEN) {
+          alert('로그인이 만료되었습니다.');
+          window.location.reload();
+        }
+      }
+    }
 
     const newDonationList = await requestCreatorPublicDonationList(creatorId);
 


### PR DESCRIPTION
자신의 후원목록을 불러오는 과정에서 '유효하지 않은 토큰' 에러 발생시
로그인이 만료되었습니다. 메세지와 함께 새로고침