### PR TITLE
[#259] 정산 관리 페이지 마크업 및 기능 구현 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,8 @@ import { CreatorId, OAuthProvider } from './types';
 import RefundCertificationPage from './pages/Refund/Certification/RefundCertificationPage';
 import RefundApplyPage from './pages/Refund/Apply/RefundApplyPage';
 import RefundConfirmPage from './pages/Refund/Confirm/RefundConfirmPage';
+import { useWindowResize } from './utils/useWindowResize';
+import SettlementPage from './pages/Settlement/SettlementPage';
 
 export interface ParamTypes {
   oauthProvider: OAuthProvider;
@@ -34,8 +36,10 @@ export interface ParamTypes {
 const App = () => {
   const { pathname } = useLocation();
   const accessToken = useRecoilValue(accessTokenState);
+  const { useWindowResizeInitEffect } = useWindowResize();
 
   useInitScrollTopEffect(pathname);
+  useWindowResizeInitEffect();
 
   return (
     <>
@@ -87,6 +91,13 @@ const App = () => {
         <PrivateRoute
           path="/creator/:creatorId/statistic"
           component={StatisticsPage}
+          isAuthed={!!accessToken}
+          redirectTo="/login"
+        />
+
+        <PrivateRoute
+          path="/creator/:creatorId/settlement"
+          component={SettlementPage}
           isAuthed={!!accessToken}
           redirectTo="/login"
         />

--- a/client/src/components/@molecule/Carousel/Carousel.styles.ts
+++ b/client/src/components/@molecule/Carousel/Carousel.styles.ts
@@ -1,0 +1,40 @@
+import styled, { css } from 'styled-components';
+import IconButton from '../../@atom/IconButton/IconButton';
+import LeftArrow from '../../../assets/icons/left-arrow.svg';
+import RightArrow from '../../../assets/icons/right-arrow.svg';
+
+export const StyledCarousel = styled.div`
+  margin: 0 3rem;
+  position: relative;
+  width: fit-content;
+`;
+
+interface ContentContainerProps {
+  contentWidth?: number;
+}
+
+export const ContentContainer = styled.div<ContentContainerProps>`
+  width: ${({ contentWidth }) => contentWidth ?? '100%'};
+  display: flex;
+  overflow: hidden;
+`;
+
+const ArrowStyle = css`
+  position: absolute;
+  bottom: 2.5rem;
+  width: 1.5rem;
+
+  &:hover {
+    opacity: 0.5;
+  }
+`;
+
+export const LeftArrowButton = styled(IconButton).attrs({ src: LeftArrow })`
+  ${ArrowStyle}
+  left: -3rem;
+`;
+
+export const RightArrowButton = styled(IconButton).attrs({ src: RightArrow })`
+  ${ArrowStyle}
+  right: -3rem;
+`;

--- a/client/src/components/@molecule/Carousel/Carousel.tsx
+++ b/client/src/components/@molecule/Carousel/Carousel.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  StyledCarousel,
+  LeftArrowButton,
+  RightArrowButton,
+  ContentContainer,
+} from './Carousel.styles';
+
+interface CarouselProps {
+  pageCount: number;
+  children: React.ReactNode;
+  contentWidth?: number;
+  className?: string;
+}
+
+const Carousel = ({ pageCount, children, contentWidth, className }: CarouselProps) => {
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const isFirstPage = currentPage <= 0;
+  const isLastPage = currentPage >= pageCount - 1;
+
+  const showPrevList = () => {
+    if (isFirstPage) return;
+
+    setCurrentPage(currentPage - 1);
+  };
+
+  const showNextList = () => {
+    if (isLastPage) return;
+
+    setCurrentPage(currentPage + 1);
+  };
+
+  useEffect(() => {
+    if (!carouselRef.current) return;
+
+    carouselRef.current.scroll({
+      left: currentPage * carouselRef.current.clientWidth,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
+  return (
+    <StyledCarousel>
+      {!isFirstPage && <LeftArrowButton onClick={showPrevList} />}
+      <ContentContainer className={className} ref={carouselRef} contentWidth={contentWidth}>
+        {children}
+      </ContentContainer>
+      {!isLastPage && <RightArrowButton onClick={showNextList} />}
+    </StyledCarousel>
+  );
+};
+
+export default Carousel;

--- a/client/src/components/Main/CreatorList/Desktop/DesktopCreatorList.styles.ts
+++ b/client/src/components/Main/CreatorList/Desktop/DesktopCreatorList.styles.ts
@@ -10,6 +10,7 @@ export const List = styled.ul`
   justify-content: center;
   align-items: center;
   position: relative;
+
   overflow-x: scroll;
   -ms-overflow-style: none; // ms
   scrollbar-width: none; // firefox

--- a/client/src/components/Menu/Desktop/DesktopMenu.tsx
+++ b/client/src/components/Menu/Desktop/DesktopMenu.tsx
@@ -38,9 +38,9 @@ const DesktopMenu = ({ onClose }: DesktopMenuProps) => {
         <MenuIcon src={User} />
         <span>마이페이지</span>
       </MenuButton>
-      <MenuButton onClick={() => routeTo(`/creator/${userInfo?.pageName}/statistic`)}>
+      <MenuButton onClick={() => routeTo(`/creator/${userInfo?.pageName}/settlement`)}>
         <MenuIcon src={Graph} />
-        <span>통계</span>
+        <span>정산 관리</span>
       </MenuButton>
       <MenuButton onClick={() => routeTo(`/creator/${userInfo?.pageName}/setting`)}>
         <MenuIcon src={Setting} />

--- a/client/src/components/Menu/Mobile/MobileMenu.tsx
+++ b/client/src/components/Menu/Mobile/MobileMenu.tsx
@@ -33,8 +33,8 @@ const MobileMenu = ({ onClose }: MobileMenuProps) => {
       <StyledAnchor to={`/creator/${userInfo?.pageName}`} onClick={onClose}>
         마이페이지
       </StyledAnchor>
-      <StyledAnchor to={`/creator/${userInfo?.pageName}/statistic`} onClick={onClose}>
-        후원 통계
+      <StyledAnchor to={`/creator/${userInfo?.pageName}/settlement`} onClick={onClose}>
+        정산 관리
       </StyledAnchor>
       <StyledAnchor to={`/creator/${userInfo?.pageName}/setting`} onClick={onClose}>
         설정

--- a/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo styles.ts
+++ b/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import PALETTE from '../../../../constants/palette';
+import Container from '../../../@atom/Container/Container.styles';
+import SubTitle from '../../../@atom/SubTitle/SubTitle.styles';
+
+export const StyledSettlementInfo = styled.div`
+  display: flex;
+  width: 77.5rem;
+  justify-content: space-between;
+`;
+
+export const InfoContainer = styled(Container)`
+  width: 21.25rem;
+  height: 34rem;
+  border-top: 2px solid ${PALETTE.GRAY_300};
+  border-bottom: 2px solid ${PALETTE.GRAY_300};
+  justify-content: space-around;
+  position: relative;
+`;
+
+export const StyledSubTitle = styled(SubTitle)``;
+
+export const StyledCommonSubTitle = styled(SubTitle)``;
+
+export const Caution = styled.p``;
+
+export const AmountContainer = styled(Container)``;
+
+export const Amount = styled.span`
+  display: inline-block;
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 1.75rem 0.5rem;
+`;

--- a/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.stories.tsx
+++ b/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.stories.tsx
@@ -1,0 +1,10 @@
+import { Story } from '@storybook/react';
+import SettlementInfo from './DesktopSettlementInfo';
+
+export default {
+  title: 'components/settlement/info/desktop',
+};
+
+const Template: Story = (args) => <SettlementInfo {...args} />;
+
+export const Default = Template.bind({});

--- a/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.tsx
+++ b/client/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.tsx
@@ -1,0 +1,54 @@
+import useSettlement from '../../../../service/hooks/user/useSettlement';
+import useUserInfo from '../../../../service/hooks/user/useUserInfo';
+import { toCommaSeparatedString } from '../../../../utils/format';
+import Button from '../../../@atom/Button/Button.styles';
+import {
+  InfoContainer,
+  StyledSubTitle,
+  Caution,
+  Amount,
+  StyledSettlementInfo,
+  AmountContainer,
+} from './DesktopSettlementInfo styles';
+
+const DesktopSettlementInfo = () => {
+  const { donationAmount, settlableAmount, settledAmount, applySettlement } = useSettlement();
+  const nextMonth = new Date().getMonth() + 1;
+
+  return (
+    <StyledSettlementInfo>
+      <InfoContainer>
+        <StyledSubTitle>현재까지 정산 받은 금액은</StyledSubTitle>
+        <AmountContainer>
+          <span>
+            <Amount>{toCommaSeparatedString(settledAmount)}</Amount>원
+          </span>
+          <Caution>Thank You For 에서 정산받은 총 금액입니다</Caution>
+        </AmountContainer>
+        <Button disabled>정산 내역확인하기</Button>
+      </InfoContainer>
+      <InfoContainer>
+        <StyledSubTitle>현재 도네이션 받은 금액은</StyledSubTitle>
+        <AmountContainer>
+          <span>
+            <Amount>{toCommaSeparatedString(donationAmount)}</Amount>원
+          </span>
+          <Caution>도네이션 받은 날짜 기준 7일 후 정산이 가능합니다.</Caution>
+        </AmountContainer>
+        <Button disabled>도네이션 내역 확인하기</Button>
+      </InfoContainer>
+      <InfoContainer>
+        <StyledSubTitle>정산 받을 수 있는 금액은</StyledSubTitle>
+        <AmountContainer>
+          <span>
+            <Amount>{toCommaSeparatedString(settlableAmount)}</Amount>원
+          </span>
+          <Caution>오늘 요청시 환급일 2021/{nextMonth}/28</Caution>
+        </AmountContainer>
+        <Button onClick={applySettlement}>정산 신청하기</Button>
+      </InfoContainer>
+    </StyledSettlementInfo>
+  );
+};
+
+export default DesktopSettlementInfo;

--- a/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo styles.ts
+++ b/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo styles.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { SIZE } from '../../../../constants/device';
+import Container from '../../../@atom/Container/Container.styles';
+import SubTitle from '../../../@atom/SubTitle/SubTitle.styles';
+import Carousel from '../../../@molecule/Carousel/Carousel';
+
+export const StyledSettlementInfo = styled.div`
+  position: relative;
+  max-width: ${SIZE.MOBILE_MAX}px;
+`;
+
+export const InfoContainer = styled(Container)`
+  min-width: 100%;
+`;
+
+export const StyledSubTitle = styled(SubTitle)`
+  width: 100%;
+  text-align: left;
+`;
+
+export const StyledCommonSubTitle = styled(SubTitle)`
+  width: 100%;
+  text-align: left;
+  margin-left: 3rem;
+`;
+
+export const Caution = styled.p`
+  font-size: 0.75rem;
+`;
+
+export const AmountContainer = styled.div`
+  font-weight: 700;
+`;
+
+export const Amount = styled.span`
+  display: inline-block;
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 1.75rem 0.5rem;
+`;
+
+export const StyledCarousel = styled(Carousel)`
+  width: 16rem;
+  margin-bottom: 6rem;
+`;

--- a/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo.stories.tsx
+++ b/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo.stories.tsx
@@ -1,0 +1,10 @@
+import { Story } from '@storybook/react';
+import SettlementInfo from './MobileSettlementInfo';
+
+export default {
+  title: 'components/settlement/info/mobile',
+};
+
+const Template: Story = (args) => <SettlementInfo {...args} />;
+
+export const Default = Template.bind({});

--- a/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo.tsx
+++ b/client/src/components/Settlement/Info/Mobile/MobileSettlementInfo.tsx
@@ -1,0 +1,52 @@
+import useSettlement from '../../../../service/hooks/user/useSettlement';
+import useUserInfo from '../../../../service/hooks/user/useUserInfo';
+import { toCommaSeparatedString } from '../../../../utils/format';
+import Button from '../../../@atom/Button/Button.styles';
+import {
+  InfoContainer,
+  StyledSubTitle,
+  Caution,
+  StyledCarousel,
+  Amount,
+  StyledSettlementInfo,
+  AmountContainer,
+  StyledCommonSubTitle,
+} from './MobileSettlementInfo styles';
+
+const MobileSettlementInfo = () => {
+  const { userInfo } = useUserInfo();
+  const { donationAmount, settlableAmount, settledAmount, applySettlement } = useSettlement();
+  const nextMonth = new Date().getMonth() + 1;
+
+  return (
+    <StyledSettlementInfo>
+      <StyledCommonSubTitle>{userInfo?.nickname}님이</StyledCommonSubTitle>
+      <StyledCarousel pageCount={3}>
+        <InfoContainer>
+          <StyledSubTitle>현재 도네이션 받은 금액은</StyledSubTitle>
+          <AmountContainer>
+            <Amount>{toCommaSeparatedString(donationAmount)}</Amount>원
+          </AmountContainer>
+          <Caution>도네이션 받은 날짜 기준 7일 후 정산이 가능합니다.</Caution>
+        </InfoContainer>
+        <InfoContainer>
+          <StyledSubTitle>정산 받을 수 있는 금액은</StyledSubTitle>
+          <AmountContainer>
+            <Amount>{toCommaSeparatedString(settlableAmount)}</Amount>원
+          </AmountContainer>
+          <Caution>오늘 요청시 환급일 2021/{nextMonth}/28</Caution>
+        </InfoContainer>
+        <InfoContainer>
+          <StyledSubTitle>현재까지 정산 받은 금액은</StyledSubTitle>
+          <AmountContainer>
+            <Amount>{toCommaSeparatedString(settledAmount)}</Amount>원
+          </AmountContainer>
+          <Caution>Thank You For 에서 정산받은 총 금액입니다</Caution>
+        </InfoContainer>
+      </StyledCarousel>
+      <Button onClick={applySettlement}>정산 신청하기</Button>
+    </StyledSettlementInfo>
+  );
+};
+
+export default MobileSettlementInfo;

--- a/client/src/components/Settlement/Info/SettlementInfo.tsx
+++ b/client/src/components/Settlement/Info/SettlementInfo.tsx
@@ -1,0 +1,12 @@
+import { SIZE } from '../../../constants/device';
+import { useWindowResize } from '../../../utils/useWindowResize';
+import DesktopSettlementInfo from './Desktop/DesktopSettlementInfo';
+import MobileSettlementInfo from './Mobile/MobileSettlementInfo';
+
+const SettlementInfo = () => {
+  const { windowWidth } = useWindowResize();
+
+  return windowWidth > SIZE.MOBILE_MAX ? <DesktopSettlementInfo /> : <MobileSettlementInfo />;
+};
+
+export default SettlementInfo;

--- a/client/src/constants/style.ts
+++ b/client/src/constants/style.ts
@@ -1,3 +1,5 @@
+import { css } from 'styled-components';
+
 export const Z_INDEX = {
   FOREGROUND: 999,
   MIDGROUND: 99,
@@ -5,3 +7,10 @@ export const Z_INDEX = {
 };
 
 export const MIN_PAGE_HEIGHT = 'calc(100vh - 4rem)';
+
+export const flexCenterStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/client/src/pages/Settlement/SettlementPage.stories.tsx
+++ b/client/src/pages/Settlement/SettlementPage.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta, Story } from '@storybook/react';
+import SettlementPage from './SettlementPage';
+
+export default {
+  title: 'pages/settlement',
+} as Meta;
+
+const Template: Story = (args) => <SettlementPage {...args} />;
+
+export const Default = Template.bind({});

--- a/client/src/pages/Settlement/SettlementPage.styles.ts
+++ b/client/src/pages/Settlement/SettlementPage.styles.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import Template from '../../components/@atom/Template/Template';
+import Title from '../../components/@atom/Title/Title.styles';
+
+export const StyledTemplate = styled(Template)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  section:nth-of-type(1) {
+    margin-bottom: 10rem;
+  }
+`;
+
+export const StyledTitle = styled(Title)`
+  margin-bottom: 6rem;
+`;

--- a/client/src/pages/Settlement/SettlementPage.tsx
+++ b/client/src/pages/Settlement/SettlementPage.tsx
@@ -1,0 +1,15 @@
+import SettlementInfo from '../../components/Settlement/Info/SettlementInfo';
+import { StyledTemplate, StyledTitle } from './SettlementPage.styles';
+
+const SettlementPage = () => {
+  return (
+    <StyledTemplate>
+      <StyledTitle>정산 관리</StyledTitle>
+      <section>
+        <SettlementInfo />
+      </section>
+    </StyledTemplate>
+  );
+};
+
+export default SettlementPage;

--- a/client/src/service/hooks/creator/useCreatorList.ts
+++ b/client/src/service/hooks/creator/useCreatorList.ts
@@ -29,7 +29,7 @@ const useCreatorList = () => {
     if (!listRef.current) return;
 
     listRef.current.scroll({
-      left: currentPage * 720,
+      left: currentPage * listRef.current.clientWidth,
       behavior: 'smooth',
     });
   }, [currentPage]);

--- a/client/src/service/hooks/donation/useDonation.ts
+++ b/client/src/service/hooks/donation/useDonation.ts
@@ -17,7 +17,7 @@ const useDonation = (creatorId: CreatorId) => {
     const { merchantUid } = await requestPayment({ amount, email, pageName });
     const { IMP } = window;
 
-    const accountId = 'imp52497817';
+    const accountId = process.env.NODE_ENV === 'production' ? 'imp52497817' : 'imp61348931';
 
     IMP.init(accountId);
 
@@ -39,6 +39,8 @@ const useDonation = (creatorId: CreatorId) => {
 
       try {
         const donationResult = await requestPaymentComplete(response);
+
+        console.log(donationResult);
 
         setDonation(donationResult);
         alert('결제에 성공했습니다.');

--- a/client/src/service/hooks/user/useSettlement.ts
+++ b/client/src/service/hooks/user/useSettlement.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import { requestIdState } from '../../state/request';
+import { settlementQuery, settlementQueryKey } from '../../state/settlement';
+
+const useSettlement = () => {
+  const { donationAmount, settlableAmount, settledAmount } = useRecoilValue(settlementQuery);
+  const setRequestId = useSetRecoilState(requestIdState(settlementQueryKey));
+
+  useEffect(() => {
+    setRequestId((prev) => prev + 1);
+  }, []);
+
+  const applySettlement = () => {};
+
+  return { donationAmount, settlableAmount, settledAmount, applySettlement };
+};
+
+export default useSettlement;

--- a/client/src/service/hooks/user/useStatistics.ts
+++ b/client/src/service/hooks/user/useStatistics.ts
@@ -1,15 +1,15 @@
 import { useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { requestIdState } from '../../state/request';
 
 import { userStatisticsQuery, userStatisticsQueryKey } from '../../state/statistics';
 
 const useStatistics = () => {
   const { point: totalAmount } = useRecoilValue(userStatisticsQuery);
-  const [requestId, setRequestId] = useRecoilState(requestIdState(userStatisticsQueryKey));
+  const setRequestId = useSetRecoilState(requestIdState(userStatisticsQueryKey));
 
   useEffect(() => {
-    setRequestId(requestId + 1);
+    setRequestId((prev) => prev + 1);
   }, []);
 
   return { totalAmount };

--- a/client/src/service/request/refund.ts
+++ b/client/src/service/request/refund.ts
@@ -2,14 +2,14 @@ import { apiClient, authorizationHeader } from '../../API';
 import { Refund, refundOrderDetail } from '../../types';
 
 export const requestVerifyMerchantUid = (merchantUid: string): Promise<Refund> => {
-  return apiClient.get('/payments/refund/verification/ready'); // { merchantUid }
+  return apiClient.post('/payments/refund/verification/ready', { merchantUid });
 };
 
 export const requestVerify = (
   merchantUid: string,
   verificationCode: string
 ): Promise<{ refundAccessToken: string }> => {
-  return apiClient.get('/payments/refund/verification'); // , { merchantUid, verificationCode }
+  return apiClient.post('/payments/refund/verification', { merchantUid, verificationCode });
 };
 
 export const requestRefundOrderInfo = (refundAccessToken: string): Promise<refundOrderDetail> => {

--- a/client/src/service/state/settlement.ts
+++ b/client/src/service/state/settlement.ts
@@ -1,0 +1,20 @@
+import { selector } from 'recoil';
+import { accessTokenState } from './login';
+import { requestIdState } from './request';
+
+export const settlementQueryKey = 'settlementQuery';
+
+export const settlementQuery = selector({
+  key: settlementQueryKey,
+  get: ({ get }) => {
+    get(accessTokenState);
+    get(requestIdState(settlementQueryKey));
+
+    // TODO: api 스키마 확정되면 api request함수 작성
+    return Promise.resolve({
+      donationAmount: 52000,
+      settlableAmount: 90000,
+      settledAmount: 800000,
+    });
+  },
+});

--- a/client/src/utils/useWindowResize.ts
+++ b/client/src/utils/useWindowResize.ts
@@ -1,19 +1,27 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
+import { atom, useRecoilState } from 'recoil';
+
+const windowWidthState = atom({
+  key: 'windowWidthState',
+  default: window.innerWidth,
+});
 
 export function useWindowResize() {
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [windowWidth, setWindowWidth] = useRecoilState(windowWidthState);
 
   const onResize = () => {
     setWindowWidth(window.innerWidth);
   };
 
-  useEffect(() => {
-    window.addEventListener('resize', onResize);
+  const useWindowResizeInitEffect = () => {
+    useEffect(() => {
+      window.addEventListener('resize', onResize);
 
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-  }, []);
+      return () => {
+        window.removeEventListener('resize', onResize);
+      };
+    }, []);
+  };
 
-  return { windowWidth };
+  return { windowWidth, useWindowResizeInitEffect };
 }


### PR DESCRIPTION
- api 요청함수 만들어서 교체하면 기능 완성! (api 스키마 미완성)
- Carousel 컴포넌트 따로 분리해서 구현 (메인페이지의 창작자 리스트도 추후 교체예정)
- windowResize 전역상태로 변경(useWindowResize 훅을 호출하는 컴포넌트가 늘어갈 때마다 이벤트리스너가 추가되는 현상 해결)

