### PR TITLE
[#250]백오피스에서 정산 가능 계정을 승인 및 반려 한다.

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -7,6 +7,7 @@ endif::[]
 :toc: left
 :toclevels: 4
 == Members (회원)
+
 === 페이지 유효성 검사 - 성공
 ==== Request
 include::{snippets}/validatePageName/http-request.adoc[]
@@ -207,6 +208,11 @@ include::{snippets}/accountInfoInvalidTokenFailed/http-response.adoc[]
 include::{snippets}/registerAccount/http-request.adoc[]
 ==== Response
 include::{snippets}/registerAccount/http-response.adoc[]
+=== 정산 계좌 등록 요청 - 유효하지 않은 Request
+==== Request
+include::{snippets}/registerAccountFailWhenInvalidValue/http-request.adoc[]
+==== Response
+include::{snippets}/registerAccountFailWhenInvalidValue/http-response.adoc[]
 === 정산 계좌 등록 요청 - 이미 정산 계좌가 등록되어 있는 경우
 ==== Request
 include::{snippets}/registerAccountFailRegistered/http-request.adoc[]
@@ -227,8 +233,6 @@ include::{snippets}/registerAccountHeaderNotFoundFailed/http-response.adoc[]
 include::{snippets}/registerAccountInvalidTokenFailed/http-request.adoc[]
 ==== Response
 include::{snippets}/registerAccountInvalidTokenFailed/http-response.adoc[]
-
-
 
 == Banners (배너)
 === 배너 이미지 목록 조회 - 성공
@@ -386,7 +390,7 @@ include::{snippets}/refundPayment/http-request.adoc[]
 ==== Response
 include::{snippets}/refundPayment/http-response.adoc[]
 
-== Banners (배너)
+== Oauth2.0 (회원가입 및 인증)
 === Oauth를 이용한 로그인 - 성공
 ==== Request
 include::{snippets}/login/http-request.adoc[]

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -432,3 +432,20 @@ include::{snippets}/signUpRequestFailed/http-response.adoc[]
 include::{snippets}/signUpInvalidOauth2TypeFailed/http-request.adoc[]
 ==== Response
 include::{snippets}/signUpInvalidOauth2TypeFailed/http-response.adoc[]
+
+== Admin (관리자)
+=== 계좌 등록 요청 승인
+==== Request
+include::{snippets}/approveAccount/http-request.adoc[]
+==== Response
+include::{snippets}/approveAccount/http-response.adoc[]
+=== 계좌 등록 요청 반려
+==== Request
+include::{snippets}/cancelAccount/http-request.adoc[]
+==== Response
+include::{snippets}/cancelAccount/http-response.adoc[]
+=== 계좌 등록 요청 조회
+==== Request
+include::{snippets}/requestingAccounts/http-request.adoc[]
+==== Response
+include::{snippets}/requestingAccounts/http-response.adoc[]

--- a/server/src/main/java/com/example/tyfserver/DataLoader.java
+++ b/server/src/main/java/com/example/tyfserver/DataLoader.java
@@ -6,7 +6,9 @@ import com.example.tyfserver.banner.repository.BannerRepository;
 import com.example.tyfserver.donation.domain.Donation;
 import com.example.tyfserver.donation.domain.Message;
 import com.example.tyfserver.donation.repository.DonationRepository;
+import com.example.tyfserver.member.domain.Account;
 import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.repository.AccountRepository;
 import com.example.tyfserver.member.repository.MemberRepository;
 import com.example.tyfserver.payment.domain.Payment;
 import com.example.tyfserver.payment.repository.PaymentRepository;
@@ -24,6 +26,7 @@ public class DataLoader implements CommandLineRunner {
     private final BannerRepository bannerRepository;
     private final DonationRepository donationRepository;
     private final PaymentRepository paymentRepository;
+    private final AccountRepository accountRepository;
 
     @Override
     public void run(String... args) {
@@ -31,18 +34,41 @@ public class DataLoader implements CommandLineRunner {
             return;
         }
 
+        Account account1 = accountRepository.save(new Account());
+        Member member1 = new Member("Rok93@naver.com", "로키", "rokiMountain", Oauth2Type.NAVER);
+        member1.addInitialAccount(account1);
         Member roki = memberRepository
-                .save(new Member("Rok93@naver.com", "로키", "rokiMountain", Oauth2Type.NAVER));
+                .save(member1);
+
+        Account account2 = accountRepository.save(new Account());
+        Member member2 = new Member("DWL5@kakao.com", "수리", "soorisooriMahaSoori", Oauth2Type.KAKAO);
+        member2.addInitialAccount(account2);
         Member soori = memberRepository
-                .save(new Member("DWL5@kakao.com", "수리", "soorisooriMahaSoori", Oauth2Type.KAKAO));
+                .save(member2);
+
+        Account account3 = accountRepository.save(new Account());
+        Member member3 = new Member("Be-poz@google.com", "파즈", "allIsBePozzible", Oauth2Type.GOOGLE);
+        member3.addInitialAccount(account3);
         Member bePoz = memberRepository
-                .save(new Member("Be-poz@google.com", "파즈", "allIsBePozzible", Oauth2Type.GOOGLE));
+                .save(member3);
+
+        Account account4 = accountRepository.save(new Account());
+        Member member4 = new Member("Joykim@naver.com", "조이", "enjoyLife", Oauth2Type.NAVER);
+        member4.addInitialAccount(account4);
         Member joy = memberRepository
-                .save(new Member("Joykim@naver.com", "조이", "enjoyLife", Oauth2Type.NAVER));
+                .save(member4);
+
+        Account account5 = accountRepository.save(new Account());
+        Member member5 = new Member("jho2301@kakao.com", "파노", "hwanorama", Oauth2Type.KAKAO);
+        member5.addInitialAccount(account5);
         Member hwano = memberRepository
-                .save(new Member("jho2301@kakao.com", "파노", "hwanorama", Oauth2Type.KAKAO));
+                .save(member5);
+
+        Account account6 = accountRepository.save(new Account());
+        Member member6 = new Member("hchayan@google.com", "인치", "1inch", Oauth2Type.GOOGLE);
+        member6.addInitialAccount(account6);
         Member inch = memberRepository
-                .save(new Member("hchayan@google.com", "인치", "1inch", Oauth2Type.GOOGLE));
+                .save(member6);
 
         bannerRepository.save(new Banner(roki, "roki-image.png"));
         bannerRepository.save(new Banner(soori, "soori-image.png"));

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,0 +1,8 @@
+package com.example.tyfserver.admin.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminController {
+
+}

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -6,33 +6,31 @@ import com.example.tyfserver.admin.service.AdminService;
 import com.example.tyfserver.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/admin")
 @RequiredArgsConstructor
 public class AdminController {
 
     private final AdminService adminService;
 
-    @PostMapping("/admin/approve/{member_id}/account")
+    @PostMapping("/approve/{member_id}/account")
     public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
         adminService.approveAccount(member_id);;
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/admin/cancel/{member_id}/account")
+    @PostMapping("/cancel/{member_id}/account")
     public ResponseEntity<Void> cancelAccount(@PathVariable("member_id") Long member_id,
                                               AccountCancelRequest accountCancelRequest) {
         adminService.cancelAccount(member_id, accountCancelRequest);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/admin/list/account")
+    @GetMapping("/list/account")
     public ResponseEntity<List<RequestingAccountResponse>> requestingAccounts() {
         return ResponseEntity.ok(adminService.findRequestingAccounts());
     }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -3,7 +3,6 @@ package com.example.tyfserver.admin.controller;
 import com.example.tyfserver.admin.dto.AccountCancelRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.admin.service.AdminService;
-import com.example.tyfserver.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,10 +22,10 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/cancel/{memberId}/account")
-    public ResponseEntity<Void> cancelAccount(Long memberId,
+    @PostMapping("/reject/{memberId}/account")
+    public ResponseEntity<Void> rejectAccount(Long memberId,
                                               AccountCancelRequest accountCancelRequest) {
-        adminService.cancelAccount(memberId, accountCancelRequest);
+        adminService.rejectAccount(memberId, accountCancelRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,6 +1,6 @@
 package com.example.tyfserver.admin.controller;
 
-import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.AccountRejectRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +17,15 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping("/approve/{memberId}/account")
-    public ResponseEntity<Void> approveAccount(Long memberId) {
+    public ResponseEntity<Void> approveAccount(@PathVariable Long memberId) {
         adminService.approveAccount(memberId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reject/{memberId}/account")
-    public ResponseEntity<Void> rejectAccount(Long memberId,
-                                              AccountCancelRequest accountCancelRequest) {
-        adminService.rejectAccount(memberId, accountCancelRequest);
+    public ResponseEntity<Void> rejectAccount(@PathVariable Long memberId,
+                                              AccountRejectRequest accountRejectRequest) {
+        adminService.rejectAccount(memberId, accountRejectRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,8 +1,28 @@
 package com.example.tyfserver.admin.controller;
 
+import com.example.tyfserver.admin.service.AdminService;
+import com.example.tyfserver.common.util.S3Connector;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class AdminController {
 
+    private final AdminService adminService;
+    private final S3Connector s3Connector;
+
+    @PostMapping("/admin/approve/{member_id}/account")
+    public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
+        adminService.approveAccount(member_id);;
+        return null;
+    }
+
+    @PostMapping("/admin/cancel/{member_id}/account")
+    public ResponseEntity<Void> cancelAccount() {
+        return null;
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.admin.controller;
 
+import com.example.tyfserver.admin.dto.AccountCancelRequest;
 import com.example.tyfserver.admin.service.AdminService;
 import com.example.tyfserver.common.util.S3Connector;
 import lombok.RequiredArgsConstructor;
@@ -13,16 +14,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminController {
 
     private final AdminService adminService;
-    private final S3Connector s3Connector;
 
     @PostMapping("/admin/approve/{member_id}/account")
     public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
         adminService.approveAccount(member_id);;
-        return null;
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/admin/cancel/{member_id}/account")
-    public ResponseEntity<Void> cancelAccount() {
-        return null;
+    public ResponseEntity<Void> cancelAccount(@PathVariable("member_id") Long member_id,
+                                              AccountCancelRequest accountCancelRequest) {
+        adminService.cancelAccount(member_id, accountCancelRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -17,16 +17,16 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @PostMapping("/approve/{member_id}/account")
-    public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
-        adminService.approveAccount(member_id);;
+    @PostMapping("/approve/{memberId}/account")
+    public ResponseEntity<Void> approveAccount(Long memberId) {
+        adminService.approveAccount(memberId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/cancel/{member_id}/account")
-    public ResponseEntity<Void> cancelAccount(@PathVariable("member_id") Long member_id,
+    @PostMapping("/cancel/{memberId}/account")
+    public ResponseEntity<Void> cancelAccount(Long memberId,
                                               AccountCancelRequest accountCancelRequest) {
-        adminService.cancelAccount(member_id, accountCancelRequest);
+        adminService.cancelAccount(memberId, accountCancelRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,19 +1,24 @@
 package com.example.tyfserver.admin.controller;
 
 import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.admin.service.AdminService;
-import com.example.tyfserver.common.util.S3Connector;
+import com.example.tyfserver.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class AdminController {
 
     private final AdminService adminService;
+    private final MemberService memberService;
 
     @PostMapping("/admin/approve/{member_id}/account")
     public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
@@ -26,5 +31,10 @@ public class AdminController {
                                               AccountCancelRequest accountCancelRequest) {
         adminService.cancelAccount(member_id, accountCancelRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/admin/list/account/")
+    public ResponseEntity<List<RequestingAccountResponse>> requestingAccounts() {
+        return ResponseEntity.ok(memberService.findRequestingAccounts());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -32,7 +32,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/admin/list/account/")
+    @GetMapping("/admin/list/account")
     public ResponseEntity<List<RequestingAccountResponse>> requestingAccounts() {
         return ResponseEntity.ok(adminService.findRequestingAccounts());
     }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -18,7 +18,6 @@ import java.util.List;
 public class AdminController {
 
     private final AdminService adminService;
-    private final MemberService memberService;
 
     @PostMapping("/admin/approve/{member_id}/account")
     public ResponseEntity<Void> approveAccount(@PathVariable("member_id") Long member_id) {
@@ -35,6 +34,6 @@ public class AdminController {
 
     @GetMapping("/admin/list/account/")
     public ResponseEntity<List<RequestingAccountResponse>> requestingAccounts() {
-        return ResponseEntity.ok(memberService.findRequestingAccounts());
+        return ResponseEntity.ok(adminService.findRequestingAccounts());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
+++ b/server/src/main/java/com/example/tyfserver/admin/controller/AdminController.java
@@ -1,20 +1,13 @@
 package com.example.tyfserver.admin.controller;
 
 import com.example.tyfserver.admin.dto.AccountRejectRequest;
-import com.example.tyfserver.admin.dto.RequestingAccountResponse;
-import com.example.tyfserver.admin.service.AdminService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import com.example.tyfserver.admin.dto.AdminLoginRequest;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.admin.service.AdminService;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -42,7 +35,6 @@ public class AdminController {
     public ResponseEntity<List<RequestingAccountResponse>> requestingAccounts() {
         return ResponseEntity.ok(adminService.findRequestingAccounts());
     }
-    private final AdminService adminService;
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@RequestBody AdminLoginRequest adminLoginRequest) {

--- a/server/src/main/java/com/example/tyfserver/admin/dto/AccountCancelRequest.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/AccountCancelRequest.java
@@ -1,0 +1,14 @@
+package com.example.tyfserver.admin.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountCancelRequest {
+    private String cancelReason;
+
+    public AccountCancelRequest(String cancelReason) {
+        this.cancelReason = cancelReason;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/admin/dto/AccountCancelRequest.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/AccountCancelRequest.java
@@ -1,10 +1,11 @@
 package com.example.tyfserver.admin.dto;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountCancelRequest {
     private String cancelReason;
 

--- a/server/src/main/java/com/example/tyfserver/admin/dto/AccountRejectRequest.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/AccountRejectRequest.java
@@ -6,10 +6,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AccountCancelRequest {
-    private String cancelReason;
+public class AccountRejectRequest {
+    private String rejectReason;
 
-    public AccountCancelRequest(String cancelReason) {
-        this.cancelReason = cancelReason;
+    public AccountRejectRequest(String rejectReason) {
+        this.rejectReason = rejectReason;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class RequestingAccountResponse {
 
     private Long memberId;
+    private String email;
     private String nickname;
     private String pageName;
     private String accountHolder;
@@ -19,9 +20,10 @@ public class RequestingAccountResponse {
 
 
     @QueryProjection
-    public RequestingAccountResponse(Long memberId, String nickname, String pageName, String accountHolder,
+    public RequestingAccountResponse(Long memberId, String email, String nickname, String pageName, String accountHolder,
                                      String accountNumber, String bank, String bankbookImageUrl) {
         this.memberId = memberId;
+        this.email = email;
         this.nickname = nickname;
         this.pageName = pageName;
         this.accountHolder = accountHolder;

--- a/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
@@ -1,0 +1,32 @@
+package com.example.tyfserver.admin.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestingAccountResponse {
+
+    private Long memberId;
+    private String nickname;
+    private String pageName;
+    private String accountHolder;
+    private String accountNumber;
+    private String bank;
+    private String bankbookImageUrl;
+
+
+    @QueryProjection
+    public RequestingAccountResponse(Long memberId, String nickname, String pageName, String accountHolder,
+                                     String accountNumber, String bank, String bankbookImageUrl) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.pageName = pageName;
+        this.accountHolder = accountHolder;
+        this.accountNumber = accountNumber;
+        this.bank = bank;
+        this.bankbookImageUrl = bankbookImageUrl;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
+++ b/server/src/main/java/com/example/tyfserver/admin/dto/RequestingAccountResponse.java
@@ -1,9 +1,12 @@
 package com.example.tyfserver.admin.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
+import com.example.tyfserver.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,8 +21,6 @@ public class RequestingAccountResponse {
     private String bank;
     private String bankbookImageUrl;
 
-
-    @QueryProjection
     public RequestingAccountResponse(Long memberId, String email, String nickname, String pageName, String accountHolder,
                                      String accountNumber, String bank, String bankbookImageUrl) {
         this.memberId = memberId;
@@ -30,5 +31,13 @@ public class RequestingAccountResponse {
         this.accountNumber = accountNumber;
         this.bank = bank;
         this.bankbookImageUrl = bankbookImageUrl;
+    }
+
+    public static List<RequestingAccountResponse> toList(List<Member> members) {
+        return members.stream()
+                .map(member -> new RequestingAccountResponse(member.getId(), member.getEmail(),
+                        member.getNickname(), member.getPageName(), member.getAccount().getAccountHolder(),
+                        member.getAccount().getAccountNumber(), member.getAccount().getBank(), member.getBankBookUrl()))
+                .collect(Collectors.toList());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -29,9 +29,9 @@ public class AdminService {
         smtpMailConnector.sendAccountApprove(member.getEmail());
     }
 
-    public void cancelAccount(Long memberId, AccountCancelRequest accountCancelRequest) {
+    public void rejectAccount(Long memberId, AccountCancelRequest accountCancelRequest) {
         Member member = findMember(memberId);
-        member.cancelAccount();
+        member.rejectAccount();
         smtpMailConnector.sendAccountCancel(member.getEmail(), accountCancelRequest.getCancelReason());
     }
 

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -19,15 +19,15 @@ public class AdminService {
     private final S3Connector s3Connector;
     private final SmtpMailConnector smtpMailConnector;
 
-    public void approveAccount(Long member_id) {
-        Member member = findMember(member_id);
+    public void approveAccount(Long memberId) {
+        Member member = findMember(memberId);
         member.approveAccount();
         s3Connector.delete(member.getBankBookUrl());
         smtpMailConnector.sendAccountApprove(member.getEmail());
     }
 
-    public void cancelAccount(Long member_id, AccountCancelRequest accountCancelRequest) {
-        Member member = findMember(member_id);
+    public void cancelAccount(Long memberId, AccountCancelRequest accountCancelRequest) {
+        Member member = findMember(memberId);
         member.cancelAccount();
         smtpMailConnector.sendAccountCancel(member.getEmail(), accountCancelRequest.getCancelReason());
     }
@@ -36,5 +36,4 @@ public class AdminService {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
     }
-
 }

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -1,9 +1,32 @@
 package com.example.tyfserver.admin.service;
 
+import com.example.tyfserver.common.util.S3Connector;
+import com.example.tyfserver.common.util.SmtpMailConnector;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.exception.MemberNotFoundException;
+import com.example.tyfserver.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class AdminService {
+
+    private final MemberRepository memberRepository;
+    private final S3Connector s3Connector;
+    private final SmtpMailConnector smtpMailConnector;
+
+    public void approveAccount(Long member_id) {
+        Member member = findMember(member_id);
+        member.approveAccount();
+        s3Connector.delete(member.getBankBookUrl());
+        smtpMailConnector.sendAccountApprove(member.getEmail());
+    }
+
+    private Member findMember(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -1,0 +1,9 @@
+package com.example.tyfserver.admin.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AdminService {
+}

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.admin.service;
 
+import com.example.tyfserver.admin.dto.AccountCancelRequest;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.common.util.SmtpMailConnector;
 import com.example.tyfserver.member.domain.Member;
@@ -25,8 +26,15 @@ public class AdminService {
         smtpMailConnector.sendAccountApprove(member.getEmail());
     }
 
+    public void cancelAccount(Long member_id, AccountCancelRequest accountCancelRequest) {
+        Member member = findMember(member_id);
+        member.cancelAccount();
+        smtpMailConnector.sendAccountCancel(member.getEmail(), accountCancelRequest.getCancelReason());
+    }
+
     private Member findMember(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
     }
+
 }

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -1,6 +1,6 @@
 package com.example.tyfserver.admin.service;
 
-import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.AccountRejectRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.common.util.SmtpMailConnector;
@@ -29,10 +29,10 @@ public class AdminService {
         smtpMailConnector.sendAccountApprove(member.getEmail());
     }
 
-    public void rejectAccount(Long memberId, AccountCancelRequest accountCancelRequest) {
+    public void rejectAccount(Long memberId, AccountRejectRequest accountRejectRequest) {
         Member member = findMember(memberId);
         member.rejectAccount();
-        smtpMailConnector.sendAccountCancel(member.getEmail(), accountCancelRequest.getCancelReason());
+        smtpMailConnector.sendAccountCancel(member.getEmail(), accountRejectRequest.getRejectReason());
     }
 
     private Member findMember(Long id) {
@@ -41,7 +41,7 @@ public class AdminService {
     }
 
     public List<RequestingAccountResponse> findRequestingAccounts() {
-        return memberRepository.findRequestingAccounts();
+        return RequestingAccountResponse.toList(memberRepository.findRequestingAccounts());
     }
 
 }

--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.admin.service;
 
 import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.common.util.SmtpMailConnector;
 import com.example.tyfserver.member.domain.Member;
@@ -9,6 +10,8 @@ import com.example.tyfserver.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -36,4 +39,9 @@ public class AdminService {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);
     }
+
+    public List<RequestingAccountResponse> findRequestingAccounts() {
+        return memberRepository.findRequestingAccounts();
+    }
+
 }

--- a/server/src/main/java/com/example/tyfserver/common/util/S3Connector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/S3Connector.java
@@ -25,9 +25,20 @@ public class S3Connector {
     @Value("${s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile multipartFile, String path) {
+    public String uploadProfile(MultipartFile multipartFile, Long memberId) {
         File file = convertToFile(multipartFile);
-        String fileName = path + UUID.randomUUID() + multipartFile.getOriginalFilename();
+        String fileName = "users/"
+                + memberId + "/profiles/" + UUID.randomUUID() + multipartFile.getOriginalFilename();
+        awsS3Client.putObject(new PutObjectRequest(bucket, fileName, file));
+        file.delete();
+
+        return cloudfrontUrl + fileName;
+    }
+
+    public String uploadBankBook(MultipartFile multipartFile, Long memberId) {
+        File file = convertToFile(multipartFile);
+        String fileName = "users/"
+                + memberId + "/bankbook/" + UUID.randomUUID() + multipartFile.getOriginalFilename();
         awsS3Client.putObject(new PutObjectRequest(bucket, fileName, file));
         file.delete();
 

--- a/server/src/main/java/com/example/tyfserver/common/util/S3Connector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/S3Connector.java
@@ -25,10 +25,9 @@ public class S3Connector {
     @Value("${s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile multipartFile, Long memberId) {
+    public String upload(MultipartFile multipartFile, String path) {
         File file = convertToFile(multipartFile);
-        String fileName = "users/"
-                + memberId + "/profiles/" + UUID.randomUUID() + multipartFile.getOriginalFilename();
+        String fileName = path + UUID.randomUUID() + multipartFile.getOriginalFilename();
         awsS3Client.putObject(new PutObjectRequest(bucket, fileName, file));
         file.delete();
 

--- a/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
@@ -8,14 +8,23 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class SmtpMailConnector {
-
+    private static final String PREFIX_SUBJECT = "[Thank You For]";
     private final JavaMailSender javaMailSender;
 
     public void sendVerificationCode(String mailAddress, String verificationCode) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(mailAddress);
-        message.setSubject("[Thank You For] 환불 인증번호");
+        message.setSubject(PREFIX_SUBJECT + "환불 인증번호");
         message.setText("인증번호:" + verificationCode);
+
+        javaMailSender.send(message);
+    }
+
+    public void sendAccountApprove(String mailAddress) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(mailAddress);
+        message.setSubject(PREFIX_SUBJECT + "정산 계좌 승인 완료");
+        message.setText("정산계좌 신청이 승인되었습니다.");
 
         javaMailSender.send(message);
     }

--- a/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
@@ -28,4 +28,14 @@ public class SmtpMailConnector {
 
         javaMailSender.send(message);
     }
+
+    public void sendAccountCancel(String mailAddress, String cancelReason) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(mailAddress);
+        message.setSubject(PREFIX_SUBJECT + "정산 계좌 승인 반려");
+        message.setText("정산계좌 신청이 반려되었습니다. \n " +
+                "반려사유 : " + cancelReason);
+
+        javaMailSender.send(message);
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
+++ b/server/src/main/java/com/example/tyfserver/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.tyfserver.member.controller;
 import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.auth.service.AuthenticationService;
 import com.example.tyfserver.member.dto.*;
+import com.example.tyfserver.member.exception.AccountRegisterValidationRequestException;
 import com.example.tyfserver.member.exception.BioValidationRequestException;
 import com.example.tyfserver.member.exception.NicknameValidationRequestException;
 import com.example.tyfserver.member.exception.PageNameValidationRequestException;
@@ -122,7 +123,7 @@ public class MemberController {
                                                 @Valid @ModelAttribute AccountRegisterRequest accountRegisterRequest,
                                                 BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            throw new RuntimeException();
+            throw new AccountRegisterValidationRequestException();
         }
 
         memberService.registerAccount(loginMember, accountRegisterRequest);

--- a/server/src/main/java/com/example/tyfserver/member/domain/Account.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Account.java
@@ -48,8 +48,8 @@ public class Account extends BaseTimeEntity {
         this.status = AccountStatus.REGISTERED;
     }
 
-    public void cancel() {
-        this.status = AccountStatus.CANCELLED;
+    public void reject() {
+        this.status = AccountStatus.REJECTED;
     }
 
     private void validateRegisterAccount() {

--- a/server/src/main/java/com/example/tyfserver/member/domain/AccountStatus.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/AccountStatus.java
@@ -1,7 +1,7 @@
 package com.example.tyfserver.member.domain;
 
 public enum AccountStatus {
-    UNREGISTERED("미등록"), REGISTERED("등록완료"), REQUESTING("등록요청"), CANCELLED("등록반려");
+    UNREGISTERED("미등록"), REGISTERED("등록완료"), REQUESTING("등록요청"), REJECTED("등록반려");
 
     private final String information;
 

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -124,4 +124,12 @@ public class Member extends BaseTimeEntity {
     public void reducePoint(long amount) {
         point.reduce(amount);
     }
+
+    public void approveAccount() {
+        this.account.approve();
+    }
+
+    public String getBankBookUrl() {
+        return this.account.getBankbookUrl();
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -129,6 +129,10 @@ public class Member extends BaseTimeEntity {
         this.account.approve();
     }
 
+    public void cancelAccount() {
+        this.account.cancel();
+    }
+
     public String getBankBookUrl() {
         return this.account.getBankbookUrl();
     }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -128,8 +128,8 @@ public class Member extends BaseTimeEntity {
         this.account.approve();
     }
 
-    public void cancelAccount() {
-        this.account.cancel();
+    public void rejectAccount() {
+        this.account.reject();
     }
 
     public String getBankBookUrl() {

--- a/server/src/main/java/com/example/tyfserver/member/dto/AccountInfoResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/AccountInfoResponse.java
@@ -9,15 +9,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountInfoResponse {
     private String status;
-    private String name;
+    private String accountHolder;
     private String bank;
-    private String account;
+    private String accountNumber;
 
-    private AccountInfoResponse(String status, String name, String bank, String account) {
+    private AccountInfoResponse(String status, String accountHolder, String bank, String accountNumber) {
         this.status = status;
-        this.name = name;
+        this.accountHolder = accountHolder;
         this.bank = bank;
-        this.account = account;
+        this.accountNumber = accountNumber;
     }
 
     public static AccountInfoResponse of(Account account) {

--- a/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
@@ -5,17 +5,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountRegisterRequest {
+    @NotNull
     private String accountHolder;
-    private String account;
+    @NotNull
+    private String accountNumber;
+    @NotNull
     private String bank;
+    @NotNull
     private MultipartFile bankbookImage;
 
-    public AccountRegisterRequest(String accountHolder, String account, MultipartFile bankbookImage, String bank) {
+    public AccountRegisterRequest(String accountHolder, String accountNumber, MultipartFile bankbookImage, String bank) {
         this.accountHolder = accountHolder;
-        this.account = account;
+        this.accountNumber = accountNumber;
         this.bankbookImage = bankbookImage;
         this.bank = bank;
     }

--- a/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
@@ -11,12 +11,12 @@ public class AccountRegisterRequest {
     private String accountHolder;
     private String account;
     private String bank;
-    private MultipartFile bankbook;
+    private MultipartFile bankbookImage;
 
     public AccountRegisterRequest(String accountHolder, String account, MultipartFile bankbookImage, String bank) {
         this.accountHolder = accountHolder;
         this.account = account;
-        this.bankbook = bankbookImage;
+        this.bankbookImage = bankbookImage;
         this.bank = bank;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
@@ -1,6 +1,5 @@
 package com.example.tyfserver.member.dto;
 
-import com.example.tyfserver.member.domain.Account;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,15 +8,15 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountRegisterRequest {
-    private String name;
+    private String accountHolder;
     private String account;
     private String bank;
     private MultipartFile bankbook;
 
-    public AccountRegisterRequest(String name, String account, MultipartFile bankbook, String bank) {
-        this.name = name;
+    public AccountRegisterRequest(String accountHolder, String account, MultipartFile bankbookImage, String bank) {
+        this.accountHolder = accountHolder;
         this.account = account;
-        this.bankbook = bankbook;
+        this.bankbook = bankbookImage;
         this.bank = bank;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/AccountRegisterRequest.java
@@ -5,16 +5,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountRegisterRequest {
-    @NotNull
+    @NotBlank
     private String accountHolder;
-    @NotNull
+    @NotBlank
     private String accountNumber;
-    @NotNull
+    @NotBlank
     private String bank;
     @NotNull
     private MultipartFile bankbookImage;

--- a/server/src/main/java/com/example/tyfserver/member/exception/AccountRegisterValidationRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/member/exception/AccountRegisterValidationRequestException.java
@@ -1,0 +1,12 @@
+package com.example.tyfserver.member.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class AccountRegisterValidationRequestException extends BaseException {
+    public static final String ERROR_CODE = "member-010";
+    private static final String MESSAGE = "요청된 계좌의 정보의 형식이 올바르지 않습니다.";
+
+    public AccountRegisterValidationRequestException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/member/exception/AccountRegisterValidationRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/member/exception/AccountRegisterValidationRequestException.java
@@ -3,7 +3,7 @@ package com.example.tyfserver.member.exception;
 import com.example.tyfserver.common.exception.BaseException;
 
 public class AccountRegisterValidationRequestException extends BaseException {
-    public static final String ERROR_CODE = "member-010";
+    public static final String ERROR_CODE = "member-009";
     private static final String MESSAGE = "요청된 계좌의 정보의 형식이 올바르지 않습니다.";
 
     public AccountRegisterValidationRequestException() {

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
@@ -1,11 +1,11 @@
 package com.example.tyfserver.member.repository;
 
-import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.dto.CurationsResponse;
 
 import java.util.List;
 
 public interface MemberQueryRepository {
     List<CurationsResponse> findCurations();
-    List<RequestingAccountResponse> findRequestingAccounts();
+    List<Member> findRequestingAccounts();
 }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberQueryRepository.java
@@ -1,9 +1,11 @@
 package com.example.tyfserver.member.repository;
 
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.member.dto.CurationsResponse;
 
 import java.util.List;
 
 public interface MemberQueryRepository {
     List<CurationsResponse> findCurations();
+    List<RequestingAccountResponse> findRequestingAccounts();
 }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -1,7 +1,13 @@
 package com.example.tyfserver.member.repository;
 
+import com.example.tyfserver.admin.dto.QRequestingAccountResponse;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.donation.domain.DonationStatus;
+import com.example.tyfserver.member.domain.AccountStatus;
 import com.example.tyfserver.member.dto.CurationsResponse;
 import com.example.tyfserver.member.dto.QCurationsResponse;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
@@ -9,6 +15,7 @@ import java.util.List;
 
 import static com.example.tyfserver.donation.domain.QDonation.donation;
 import static com.example.tyfserver.member.domain.QMember.member;
+import static com.example.tyfserver.member.domain.QAccount.account;
 import static com.example.tyfserver.payment.domain.QPayment.payment;
 
 public class MemberRepositoryImpl implements MemberQueryRepository {
@@ -30,6 +37,17 @@ public class MemberRepositoryImpl implements MemberQueryRepository {
                 .orderBy(payment.amount.sum().desc())
                 .offset(0)
                 .limit(10)
+                .fetch();
+    }
+
+    @Override
+    public List<RequestingAccountResponse> findRequestingAccounts() {
+        return queryFactory.select(
+                new QRequestingAccountResponse(member.id, member.nickname, member.pageName, member.account.accountHolder,
+                        member.account.accountNumber, member.account.bank, member.account.bankbookUrl))
+                .from(member)
+                .innerJoin(member.account, account)
+                .where(account.status.eq(AccountStatus.REQUESTING))
                 .fetch();
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.example.tyfserver.member.repository;
 
-import com.example.tyfserver.admin.dto.QRequestingAccountResponse;
-import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.member.domain.AccountStatus;
+import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.dto.CurationsResponse;
 import com.example.tyfserver.member.dto.QCurationsResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -38,13 +37,12 @@ public class MemberRepositoryImpl implements MemberQueryRepository {
     }
 
     @Override
-    public List<RequestingAccountResponse> findRequestingAccounts() {
-        return queryFactory.select(
-                new QRequestingAccountResponse(member.id, member.email, member.nickname, member.pageName, member.account.accountHolder,
-                        account.accountNumber, account.bank, account.bankbookUrl))
-                .from(member)
+    public List<Member> findRequestingAccounts() {
+        return queryFactory
+                .selectFrom(member)
                 .innerJoin(member.account, account)
                 .where(account.status.eq(AccountStatus.REQUESTING))
+                .fetchJoin()
                 .fetch();
 
     }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -40,10 +40,8 @@ public class MemberRepositoryImpl implements MemberQueryRepository {
     public List<Member> findRequestingAccounts() {
         return queryFactory
                 .selectFrom(member)
-                .innerJoin(member.account, account)
+                .join(member.account, account).fetchJoin()
                 .where(account.status.eq(AccountStatus.REQUESTING))
-                .fetchJoin()
                 .fetch();
-
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -2,20 +2,17 @@ package com.example.tyfserver.member.repository;
 
 import com.example.tyfserver.admin.dto.QRequestingAccountResponse;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
-import com.example.tyfserver.donation.domain.DonationStatus;
 import com.example.tyfserver.member.domain.AccountStatus;
 import com.example.tyfserver.member.dto.CurationsResponse;
 import com.example.tyfserver.member.dto.QCurationsResponse;
-
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 
 import static com.example.tyfserver.donation.domain.QDonation.donation;
-import static com.example.tyfserver.member.domain.QMember.member;
 import static com.example.tyfserver.member.domain.QAccount.account;
+import static com.example.tyfserver.member.domain.QMember.member;
 import static com.example.tyfserver.payment.domain.QPayment.payment;
 
 public class MemberRepositoryImpl implements MemberQueryRepository {
@@ -44,10 +41,11 @@ public class MemberRepositoryImpl implements MemberQueryRepository {
     public List<RequestingAccountResponse> findRequestingAccounts() {
         return queryFactory.select(
                 new QRequestingAccountResponse(member.id, member.nickname, member.pageName, member.account.accountHolder,
-                        member.account.accountNumber, member.account.bank, member.account.bankbookUrl))
+                        account.accountNumber, account.bank, account.bankbookUrl))
                 .from(member)
                 .innerJoin(member.account, account)
                 .where(account.status.eq(AccountStatus.REQUESTING))
                 .fetch();
+
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
+++ b/server/src/main/java/com/example/tyfserver/member/repository/MemberRepositoryImpl.java
@@ -40,7 +40,7 @@ public class MemberRepositoryImpl implements MemberQueryRepository {
     @Override
     public List<RequestingAccountResponse> findRequestingAccounts() {
         return queryFactory.select(
-                new QRequestingAccountResponse(member.id, member.nickname, member.pageName, member.account.accountHolder,
+                new QRequestingAccountResponse(member.id, member.email, member.nickname, member.pageName, member.account.accountHolder,
                         account.accountNumber, account.bank, account.bankbookUrl))
                 .from(member)
                 .innerJoin(member.account, account)

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -9,7 +9,6 @@ import com.example.tyfserver.member.dto.*;
 import com.example.tyfserver.member.exception.DuplicatedNicknameException;
 import com.example.tyfserver.member.exception.DuplicatedPageNameException;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
-import com.example.tyfserver.member.repository.AccountRepository;
 import com.example.tyfserver.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -104,7 +103,7 @@ public class MemberService {
 
         String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbook(),
                 "users/" + loginMember.getId() + "/bankbook/");
-        member.registerAccount(accountRegisterRequest.getName(),
+        member.registerAccount(accountRegisterRequest.getAccountHolder(),
                 accountRegisterRequest.getAccount(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
     }
 

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.member.service;
 
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.donation.domain.Donation;
@@ -112,7 +113,8 @@ public class MemberService {
         return AccountInfoResponse.of(member.getAccount());
     }
 
-    public void findRequestingAccounts() {
+    public List<RequestingAccountResponse> findRequestingAccounts() {
+        return memberRepository.findRequestingAccounts();
     }
 
     private Member findMember(Long id) {

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.example.tyfserver.member.service;
 
-import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.donation.domain.Donation;
@@ -105,7 +104,7 @@ public class MemberService {
         String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbookImage(),
                 "users/" + loginMember.getId() + "/bankbook/");
         member.registerAccount(accountRegisterRequest.getAccountHolder(),
-                accountRegisterRequest.getAccount(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
+                accountRegisterRequest.getAccountNumber(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
     }
 
     public AccountInfoResponse accountInfo(LoginMember loginMember) {

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -4,15 +4,14 @@ import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.donation.domain.Donation;
 import com.example.tyfserver.donation.repository.DonationRepository;
-import com.example.tyfserver.member.domain.Account;
-import com.example.tyfserver.member.domain.AccountStatus;
 import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.dto.*;
-import com.example.tyfserver.member.exception.*;
+import com.example.tyfserver.member.exception.DuplicatedNicknameException;
+import com.example.tyfserver.member.exception.DuplicatedPageNameException;
+import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.example.tyfserver.member.repository.AccountRepository;
 import com.example.tyfserver.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.hql.internal.ast.DetailedSemanticException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,7 +26,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final DonationRepository donationRepository;
-    private final AccountRepository accountRepository;
     private final S3Connector s3Connector;
 
     public void validatePageName(PageNameRequest request) {
@@ -65,7 +63,7 @@ public class MemberService {
     public ProfileResponse uploadProfile(MultipartFile multipartFile, LoginMember loginMember) {
         Member findMember = findMember(loginMember.getId());
         deleteProfile(findMember);
-        String uploadedFile = s3Connector.upload(multipartFile, loginMember.getId());
+        String uploadedFile = s3Connector.upload(multipartFile, "users/" + loginMember.getId() + "/profiles/");
         findMember.uploadProfileImage(uploadedFile);
         return new ProfileResponse(uploadedFile);
     }
@@ -104,7 +102,8 @@ public class MemberService {
     public void registerAccount(LoginMember loginMember, AccountRegisterRequest accountRegisterRequest) {
         Member member = findMember(loginMember.getId());
 
-        String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbook(), loginMember.getId());
+        String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbook(),
+                "users/" + loginMember.getId() + "/bankbook/");
         member.registerAccount(accountRegisterRequest.getName(),
                 accountRegisterRequest.getAccount(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
     }

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -112,11 +112,7 @@ public class MemberService {
         Member member = findMember(loginMember.getId());
         return AccountInfoResponse.of(member.getAccount());
     }
-
-    public List<RequestingAccountResponse> findRequestingAccounts() {
-        return memberRepository.findRequestingAccounts();
-    }
-
+    
     private Member findMember(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -112,7 +112,7 @@ public class MemberService {
         Member member = findMember(loginMember.getId());
         return AccountInfoResponse.of(member.getAccount());
     }
-    
+
     private Member findMember(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(MemberNotFoundException::new);

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -101,7 +101,7 @@ public class MemberService {
     public void registerAccount(LoginMember loginMember, AccountRegisterRequest accountRegisterRequest) {
         Member member = findMember(loginMember.getId());
 
-        String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbook(),
+        String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbookImage(),
                 "users/" + loginMember.getId() + "/bankbook/");
         member.registerAccount(accountRegisterRequest.getAccountHolder(),
                 accountRegisterRequest.getAccount(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
@@ -110,6 +110,9 @@ public class MemberService {
     public AccountInfoResponse accountInfo(LoginMember loginMember) {
         Member member = findMember(loginMember.getId());
         return AccountInfoResponse.of(member.getAccount());
+    }
+
+    public void findRequestingAccounts() {
     }
 
     private Member findMember(Long id) {

--- a/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
+++ b/server/src/main/java/com/example/tyfserver/member/service/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
     public ProfileResponse uploadProfile(MultipartFile multipartFile, LoginMember loginMember) {
         Member findMember = findMember(loginMember.getId());
         deleteProfile(findMember);
-        String uploadedFile = s3Connector.upload(multipartFile, "users/" + loginMember.getId() + "/profiles/");
+        String uploadedFile = s3Connector.uploadProfile(multipartFile, loginMember.getId());
         findMember.uploadProfileImage(uploadedFile);
         return new ProfileResponse(uploadedFile);
     }
@@ -102,8 +102,8 @@ public class MemberService {
     public void registerAccount(LoginMember loginMember, AccountRegisterRequest accountRegisterRequest) {
         Member member = findMember(loginMember.getId());
 
-        String uploadedBankBookUrl = s3Connector.upload(accountRegisterRequest.getBankbookImage(),
-                "users/" + loginMember.getId() + "/bankbook/");
+        String uploadedBankBookUrl = s3Connector.uploadBankBook(accountRegisterRequest.getBankbookImage(),
+                loginMember.getId());
         member.registerAccount(accountRegisterRequest.getAccountHolder(),
                 accountRegisterRequest.getAccountNumber(), accountRegisterRequest.getBank(), uploadedBankBookUrl);
     }

--- a/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
@@ -46,7 +46,7 @@ public class AcceptanceTest {
         RestAssured.port = port;
         when(oauth2ServiceConnector.getEmailFromOauth2(any(), any()))
                 .thenReturn(DEFAULT_EMAIL);
-        when(s3Connector.upload(any(), any()))
+        when(s3Connector.uploadBankBook(any(), any()))
                 .thenReturn(DEFAULT_PROFILE_IMAGE);
         doNothing().when(s3Connector).delete(anyString());
         when(paymentServiceConnector.requestPaymentInfo(any(UUID.class)))

--- a/server/src/test/java/com/example/tyfserver/admin/AdminAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/AdminAcceptanceTest.java
@@ -1,0 +1,90 @@
+package com.example.tyfserver.admin;
+
+import com.example.tyfserver.AcceptanceTest;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.auth.dto.SignUpResponse;
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.MultiPartSpecification;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MimeTypeUtils;
+
+import java.util.List;
+
+import static com.example.tyfserver.auth.AuthAcceptanceTest.회원가입_후_로그인되어_있음;
+import static com.example.tyfserver.member.MemberAcceptanceTest.계좌_등록;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdminAcceptanceTest extends AcceptanceTest {
+
+    public static ExtractableResponse<Response> 요청_계좌_승인(Long memberId) {
+        return post("/admin/approve/" + memberId + "/account", "").extract();
+    }
+
+    public static ExtractableResponse<Response> 요청_계좌_반려(Long memberId) {
+        return post("/admin/cancel/" + memberId + "/account", "").extract();
+    }
+
+    public static ExtractableResponse<Response> 요청_계좌_목록_조회() {
+        return get("/admin/list/account").extract();
+    }
+
+    @Test
+    @DisplayName("승인 요청된 계좌목록을 조회 한다.")
+    public void requestingAccounts() {
+        //given
+        SignUpResponse signUpResponse = 회원가입_후_로그인되어_있음(DEFAULT_EMAIL, "KAKAO", "nickname", "pagename");
+        계좌_등록(generateMultiPartSpecification(), "test", "1234-1234-1234", "bank", signUpResponse.getToken());
+
+        //when
+        List<RequestingAccountResponse> result = 요청_계좌_목록_조회().body().jsonPath().getList(".", RequestingAccountResponse.class);
+
+        RequestingAccountResponse data = result.get(0);
+        Assertions.assertThat(data.getEmail()).isEqualTo(DEFAULT_EMAIL);
+        Assertions.assertThat(data.getNickname()).isEqualTo("nickname");
+        Assertions.assertThat(data.getPageName()).isEqualTo("pagename");
+        Assertions.assertThat(data.getAccountHolder()).isEqualTo("test");
+        Assertions.assertThat(data.getAccountNumber()).isEqualTo("1234-1234-1234");
+        Assertions.assertThat(data.getBank()).isEqualTo("bank");
+    }
+
+    @Test
+    @DisplayName("요청된 계좌를 승인한다.")
+    public void approveAccount() {
+        //given
+        SignUpResponse signUpResponse = 회원가입_후_로그인되어_있음(DEFAULT_EMAIL, "KAKAO", "nickname", "pagename");
+        계좌_등록(generateMultiPartSpecification(), "test", "1234-1234-1234", "bank", signUpResponse.getToken());
+
+        List<RequestingAccountResponse> requestingAccounts =
+                요청_계좌_목록_조회().body().jsonPath().getList(".", RequestingAccountResponse.class);
+
+        //when
+        assertThat(요청_계좌_승인(requestingAccounts.get(0).getMemberId()).statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("요청된 계좌를 반려한다.")
+    public void cancelAccount() {
+        //given
+        SignUpResponse signUpResponse = 회원가입_후_로그인되어_있음(DEFAULT_EMAIL, "KAKAO", "nickname", "pagename");
+        계좌_등록(generateMultiPartSpecification(), "test", "1234-1234-1234", "bank", signUpResponse.getToken());
+
+        List<RequestingAccountResponse> requestingAccounts =
+                요청_계좌_목록_조회().body().jsonPath().getList(".", RequestingAccountResponse.class);
+
+        //when
+        assertThat(요청_계좌_반려(requestingAccounts.get(0).getMemberId()).statusCode()).isEqualTo(200);
+    }
+
+
+    private MultiPartSpecification generateMultiPartSpecification() {
+        return new MultiPartSpecBuilder("testImageBinary".getBytes())
+                .mimeType(MimeTypeUtils.IMAGE_JPEG.toString())
+                .controlName("bankbookImage")
+                .fileName("bankbook.jpg")
+                .build();
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/admin/AdminAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/AdminAcceptanceTest.java
@@ -25,7 +25,7 @@ public class AdminAcceptanceTest extends AcceptanceTest {
     }
 
     public static ExtractableResponse<Response> 요청_계좌_반려(Long memberId) {
-        return post("/admin/cancel/" + memberId + "/account", "").extract();
+        return post("/admin/reject/" + memberId + "/account", "").extract();
     }
 
     public static ExtractableResponse<Response> 요청_계좌_목록_조회() {

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -92,15 +92,13 @@ class AdminControllerTest {
         List<RequestingAccountResponse> responses = new ArrayList<>();
         responses.add(new RequestingAccountResponse(1L, "nickname1", "pagename1", "accountholder1",
                 "1234-1234-12341", "bank", "https://test.test.png"));
-        responses.add(new RequestingAccountResponse(1L, "nickname2", "pagename2", "accountholder2",
+        responses.add(new RequestingAccountResponse(2L, "nickname2", "pagename2", "accountholder2",
                 "1234-1234-12342", "bank", "https://test.test.png"));
 
         //when
         when(adminService.findRequestingAccounts()).thenReturn(responses);
         //then
-        mockMvc.perform(get("/admin/list/account")
-                .content(objectMapper.writeValueAsString(responses))
-                .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/admin/list/account"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$..memberId").exists())
                 .andExpect(jsonPath("$..nickname").exists())

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -73,7 +73,7 @@ class AdminControllerTest {
         //given
         AccountCancelRequest accountCancelRequest = new AccountCancelRequest("테스트취소사유");
         //when
-        doNothing().when(adminService).cancelAccount(Mockito.anyLong(), Mockito.any());
+        doNothing().when(adminService).rejectAccount(Mockito.anyLong(), Mockito.any());
         //then
         mockMvc.perform(post("/admin/cancel/1/account")
                 .content(objectMapper.writeValueAsString(accountCancelRequest))

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -1,0 +1,117 @@
+package com.example.tyfserver.admin.controller;
+
+import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.admin.service.AdminService;
+import com.example.tyfserver.auth.config.AuthenticationArgumentResolver;
+import com.example.tyfserver.auth.config.AuthenticationInterceptor;
+import com.example.tyfserver.auth.config.RefundAuthenticationArgumentResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(controllers = AdminController.class)
+@AutoConfigureRestDocs
+class AdminControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AdminService adminService;
+
+    @MockBean
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    @MockBean
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @MockBean
+    private RefundAuthenticationArgumentResolver refundAuthenticationArgumentResolver;
+
+    @Test
+    @DisplayName("/admin/approve/{memberId}/account- success")
+    public void approveAccount() throws Exception {
+        //given
+        doNothing().when(adminService).approveAccount(Mockito.anyLong());
+        //when
+        //then
+        mockMvc.perform(post("/admin/approve/1/account")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("approveAccount",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+
+    @Test
+    @DisplayName("/admin/cancel/{memberId}/account- success")
+    public void cancelAccount() throws Exception {
+        //given
+        AccountCancelRequest accountCancelRequest = new AccountCancelRequest("테스트취소사유");
+        //when
+        doNothing().when(adminService).cancelAccount(Mockito.anyLong(), Mockito.any());
+        //then
+        mockMvc.perform(post("/admin/cancel/1/account")
+                .content(objectMapper.writeValueAsString(accountCancelRequest))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("cancelAccount",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+
+    @Test
+    @DisplayName("/admin/list/account- success")
+    public void requestingAccounts() throws Exception {
+        //given
+        List<RequestingAccountResponse> responses = new ArrayList<>();
+        responses.add(new RequestingAccountResponse(1L, "nickname1", "pagename1", "accountholder1",
+                "1234-1234-12341", "bank", "https://test.test.png"));
+        responses.add(new RequestingAccountResponse(1L, "nickname2", "pagename2", "accountholder2",
+                "1234-1234-12342", "bank", "https://test.test.png"));
+
+        //when
+        when(adminService.findRequestingAccounts()).thenReturn(responses);
+        //then
+        mockMvc.perform(get("/admin/list/account")
+                .content(objectMapper.writeValueAsString(responses))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..memberId").exists())
+                .andExpect(jsonPath("$..nickname").exists())
+                .andExpect(jsonPath("$..accountHolder").exists())
+                .andExpect(jsonPath("$..accountNumber").exists())
+                .andExpect(jsonPath("$..bank").exists())
+                .andExpect(jsonPath("$..bankbookImageUrl").exists())
+                .andExpect(jsonPath("$[0].accountNumber").value("1234-1234-12341"))
+                .andDo(document("requestingAccounts",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+        ;
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -90,9 +90,9 @@ class AdminControllerTest {
     public void requestingAccounts() throws Exception {
         //given
         List<RequestingAccountResponse> responses = new ArrayList<>();
-        responses.add(new RequestingAccountResponse(1L, "nickname1", "pagename1", "accountholder1",
+        responses.add(new RequestingAccountResponse(1L, "test1@test.com", "nickname1", "pagename1", "accountholder1",
                 "1234-1234-12341", "bank", "https://test.test.png"));
-        responses.add(new RequestingAccountResponse(2L, "nickname2", "pagename2", "accountholder2",
+        responses.add(new RequestingAccountResponse(2L, "test2@test.com", "nickname2", "pagename2", "accountholder2",
                 "1234-1234-12342", "bank", "https://test.test.png"));
 
         //when

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -1,11 +1,14 @@
 package com.example.tyfserver.admin.controller;
 
 import com.example.tyfserver.admin.dto.AccountRejectRequest;
+import com.example.tyfserver.admin.dto.AdminLoginRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.admin.exception.InvalidAdminException;
 import com.example.tyfserver.admin.service.AdminService;
 import com.example.tyfserver.auth.config.AuthenticationArgumentResolver;
 import com.example.tyfserver.auth.config.AuthenticationInterceptor;
 import com.example.tyfserver.auth.config.RefundAuthenticationArgumentResolver;
+import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +29,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -142,49 +146,6 @@ class AdminControllerTest {
                         preprocessResponse(prettyPrint())))
         ;
     }
-}
-package com.example.tyfserver.admin.controller;
-
-import com.example.tyfserver.admin.dto.AdminLoginRequest;
-import com.example.tyfserver.admin.exception.InvalidAdminException;
-import com.example.tyfserver.admin.service.AdminService;
-import com.example.tyfserver.auth.dto.TokenResponse;
-import com.example.tyfserver.auth.service.AuthenticationService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@WebMvcTest(controllers = AdminController.class)
-@AutoConfigureRestDocs
-class AdminControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private AdminService adminService;
-
-    @MockBean
-    private AuthenticationService authenticationService;
 
     @Test
     @DisplayName("/admin/login - success")
@@ -195,8 +156,8 @@ class AdminControllerTest {
 
         //when //then
         mockMvc.perform(post("/admin/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").value("token"))
                 .andDo(print())
@@ -215,8 +176,8 @@ class AdminControllerTest {
 
         //when //then
         mockMvc.perform(post("/admin/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(InvalidAdminException.ERROR_CODE))
                 .andDo(print())

--- a/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
@@ -86,10 +86,10 @@ class AdminServiceTest {
         //when
         doNothing().when(s3Connector).delete(Mockito.anyString());
         doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
-        adminService.cancelAccount(member.getId(), new AccountCancelRequest("테스트취소사유"));
+        adminService.rejectAccount(member.getId(), new AccountCancelRequest("테스트취소사유"));
 
         //then
-        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.CANCELLED);
+        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REJECTED);
         Assertions.assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
         Assertions.assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
         Assertions.assertThat(member.getAccount().getBank()).isEqualTo("하나");

--- a/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
@@ -1,8 +1,12 @@
 package com.example.tyfserver.admin.service;
 
+import com.example.tyfserver.admin.domain.AdminAccount;
 import com.example.tyfserver.admin.dto.AccountRejectRequest;
+import com.example.tyfserver.admin.dto.AdminLoginRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
+import com.example.tyfserver.admin.exception.InvalidAdminException;
 import com.example.tyfserver.auth.domain.Oauth2Type;
+import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.common.util.SmtpMailConnector;
 import com.example.tyfserver.member.domain.Account;
@@ -23,7 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest
 @Transactional
@@ -46,6 +53,9 @@ class AdminServiceTest {
     @MockBean
     private SmtpMailConnector smtpMailConnector;
 
+    @MockBean
+    private AdminAccount adminAccount;
+
     @BeforeEach
     void setUp() {
         member = new Member("email", "nickname", "pagename", Oauth2Type.GOOGLE, "profile");
@@ -58,102 +68,7 @@ class AdminServiceTest {
         memberRepository.delete(member);
     }
 
-    @Test
-    @DisplayName("결제 계좌요청을 승인한다.")
-    public void approveAccount() {
-        //given
-        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
 
-        //when
-        doNothing().when(s3Connector).delete(Mockito.anyString());
-        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
-        adminService.approveAccount(member.getId());
-
-        //then
-        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REGISTERED);
-        Assertions.assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
-        Assertions.assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
-        Assertions.assertThat(member.getAccount().getBank()).isEqualTo("하나");
-        Assertions.assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
-    }
-
-    @Test
-    @DisplayName("결제 계좌요청을 반려한다. 데이터는 지우지 않음")
-    public void cancelAccount() {
-        //given
-        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
-
-        //when
-        doNothing().when(s3Connector).delete(Mockito.anyString());
-        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
-        adminService.rejectAccount(member.getId(), new AccountRejectRequest("테스트취소사유"));
-
-        //then
-        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REJECTED);
-        Assertions.assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
-        Assertions.assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
-        Assertions.assertThat(member.getAccount().getBank()).isEqualTo("하나");
-        Assertions.assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
-    }
-
-    @Test
-    @DisplayName("계좌 승인 요청중 목록을 반환한다.")
-    public void requestingAccounts() {
-        //given
-        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
-
-        Member member2 = new Member("email2", "nickname2", "pagename2", Oauth2Type.GOOGLE, "profile2");
-        member2.addInitialAccount(accountRepository.save(new Account()));
-        memberRepository.save(member2);
-
-        //when
-        doNothing().when(s3Connector).delete(Mockito.anyString());
-        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
-        List<RequestingAccountResponse> requestingAccounts = adminService.findRequestingAccounts();
-
-        //then
-        List<Member> allMembers = memberRepository.findAll();
-        Assertions.assertThat(allMembers).hasSize(2);
-        Assertions.assertThat(requestingAccounts).hasSize(1);
-
-        RequestingAccountResponse response = requestingAccounts.get(0);
-        Assertions.assertThat(response.getMemberId()).isEqualTo(member.getId());
-        Assertions.assertThat(response.getNickname()).isEqualTo(member.getNickname());
-        Assertions.assertThat(response.getPageName()).isEqualTo(member.getPageName());
-        Assertions.assertThat(response.getAccountHolder()).isEqualTo(member.getAccount().getAccountHolder());
-        Assertions.assertThat(response.getAccountNumber()).isEqualTo(member.getAccount().getAccountNumber());
-        Assertions.assertThat(response.getBank()).isEqualTo(member.getAccount().getBank());
-        Assertions.assertThat(response.getBankbookImageUrl()).isEqualTo(member.getAccount().getBankbookUrl());
-    }
-}
-package com.example.tyfserver.admin.service;
-
-import com.example.tyfserver.admin.domain.AdminAccount;
-import com.example.tyfserver.admin.dto.AdminLoginRequest;
-import com.example.tyfserver.admin.exception.InvalidAdminException;
-import com.example.tyfserver.auth.dto.Oauth2Request;
-import com.example.tyfserver.auth.dto.TokenResponse;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
-
-@SpringBootTest
-@Transactional
-class AdminServiceTest {
-
-    @Autowired
-    private AdminService adminService;
-
-    @MockBean
-    private AdminAccount adminAccount;
 
     @DisplayName("유효하지 않은 관리자 계정으로 로그인 요청을 한 경우")
     @Test
@@ -180,4 +95,71 @@ class AdminServiceTest {
                 .isExactlyInstanceOf(InvalidAdminException.class);
     }
 
+    @Test
+    @DisplayName("결제 계좌요청을 승인한다.")
+    public void approveAccount() {
+        //given
+        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
+
+        //when
+        doNothing().when(s3Connector).delete(Mockito.anyString());
+        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
+        adminService.approveAccount(member.getId());
+
+        //then
+        assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REGISTERED);
+        assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
+        assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
+        assertThat(member.getAccount().getBank()).isEqualTo("하나");
+        assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
+    }
+
+    @Test
+    @DisplayName("결제 계좌요청을 반려한다. 데이터는 지우지 않음")
+    public void cancelAccount() {
+        //given
+        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
+
+        //when
+        doNothing().when(s3Connector).delete(Mockito.anyString());
+        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
+        adminService.rejectAccount(member.getId(), new AccountRejectRequest("테스트취소사유"));
+
+        //then
+        assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REJECTED);
+        assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
+        assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
+        assertThat(member.getAccount().getBank()).isEqualTo("하나");
+        assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
+    }
+
+    @Test
+    @DisplayName("계좌 승인 요청중 목록을 반환한다.")
+    public void requestingAccounts() {
+        //given
+        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
+
+        Member member2 = new Member("email2", "nickname2", "pagename2", Oauth2Type.GOOGLE, "profile2");
+        member2.addInitialAccount(accountRepository.save(new Account()));
+        memberRepository.save(member2);
+
+        //when
+        doNothing().when(s3Connector).delete(Mockito.anyString());
+        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
+        List<RequestingAccountResponse> requestingAccounts = adminService.findRequestingAccounts();
+
+        //then
+        List<Member> allMembers = memberRepository.findAll();
+        assertThat(allMembers).hasSize(2);
+        assertThat(requestingAccounts).hasSize(1);
+
+        RequestingAccountResponse response = requestingAccounts.get(0);
+        assertThat(response.getMemberId()).isEqualTo(member.getId());
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getPageName()).isEqualTo(member.getPageName());
+        assertThat(response.getAccountHolder()).isEqualTo(member.getAccount().getAccountHolder());
+        assertThat(response.getAccountNumber()).isEqualTo(member.getAccount().getAccountNumber());
+        assertThat(response.getBank()).isEqualTo(member.getAccount().getBank());
+        assertThat(response.getBankbookImageUrl()).isEqualTo(member.getAccount().getBankbookUrl());
+    }
 }

--- a/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
@@ -1,0 +1,95 @@
+package com.example.tyfserver.admin.service;
+
+import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.auth.domain.Oauth2Type;
+import com.example.tyfserver.common.util.S3Connector;
+import com.example.tyfserver.common.util.SmtpMailConnector;
+import com.example.tyfserver.member.domain.Account;
+import com.example.tyfserver.member.domain.AccountStatus;
+import com.example.tyfserver.member.domain.Member;
+import com.example.tyfserver.member.repository.AccountRepository;
+import com.example.tyfserver.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.mockito.Mockito.doNothing;
+
+@SpringBootTest
+@Transactional
+class AdminServiceTest {
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    private Member member;
+
+    @MockBean
+    private S3Connector s3Connector;
+
+    @MockBean
+    private SmtpMailConnector smtpMailConnector;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member("email", "nickname", "pagename", Oauth2Type.GOOGLE, "profile");
+        member.addInitialAccount(accountRepository.save(new Account()));
+        memberRepository.save(member);
+    }
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.delete(member);
+    }
+
+    @Test
+    @DisplayName("결제 계좌요청을 승인한다.")
+    public void approveAccount() {
+        //given
+        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
+
+        //when
+        doNothing().when(s3Connector).delete(Mockito.anyString());
+        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
+        adminService.approveAccount(member.getId());
+
+        //then
+        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REGISTERED);
+        Assertions.assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
+        Assertions.assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
+        Assertions.assertThat(member.getAccount().getBank()).isEqualTo("하나");
+        Assertions.assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
+    }
+
+    @Test
+    @DisplayName("결제 계좌요청을 반려한다. 데이터는 지우지 않음")
+    public void cancelAccount() {
+        //given
+        member.registerAccount("테스트유저", "1234-1234-1234", "하나", "https://test.test.png");
+
+        //when
+        doNothing().when(s3Connector).delete(Mockito.anyString());
+        doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
+        adminService.cancelAccount(member.getId(), new AccountCancelRequest("테스트취소사유"));
+
+        //then
+        Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.CANCELLED);
+        Assertions.assertThat(member.getAccount().getAccountHolder()).isEqualTo("테스트유저");
+        Assertions.assertThat(member.getAccount().getAccountNumber()).isEqualTo("1234-1234-1234");
+        Assertions.assertThat(member.getAccount().getBank()).isEqualTo("하나");
+        Assertions.assertThat(member.getAccount().getBankbookUrl()).isEqualTo("https://test.test.png");
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.tyfserver.admin.service;
 
-import com.example.tyfserver.admin.dto.AccountCancelRequest;
+import com.example.tyfserver.admin.dto.AccountRejectRequest;
 import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.auth.domain.Oauth2Type;
 import com.example.tyfserver.common.util.S3Connector;
@@ -86,7 +86,7 @@ class AdminServiceTest {
         //when
         doNothing().when(s3Connector).delete(Mockito.anyString());
         doNothing().when(smtpMailConnector).sendAccountApprove(member.getEmail());
-        adminService.rejectAccount(member.getId(), new AccountCancelRequest("테스트취소사유"));
+        adminService.rejectAccount(member.getId(), new AccountRejectRequest("테스트취소사유"));
 
         //then
         Assertions.assertThat(member.getAccountStatus()).isEqualTo(AccountStatus.REJECTED);

--- a/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeTypeUtils;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.example.tyfserver.auth.AuthAcceptanceTest.회원가입_후_로그인되어_있음;
 import static com.example.tyfserver.auth.AuthAcceptanceTest.회원생성을_요청;
@@ -89,13 +91,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     public static ExtractableResponse<Response> 계좌_등록(MultiPartSpecification multiPartSpecification, String name, String account, String bank, String token) {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("accountHolder", name);
+        requestBody.put("accountNumber", account);
+        requestBody.put("bank", bank);
+
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(token)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .param("accountHolder", name)
-                .param("accountNumber", account)
-                .param("bank", bank)
+                .formParams(requestBody)
                 .multiPart(multiPartSpecification)
                 .post("/members/me/account")
                 .then().extract()

--- a/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/MemberAcceptanceTest.java
@@ -88,13 +88,14 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         return authGet("/members/me/account", token).extract();
     }
 
-    public static ExtractableResponse<Response> 계좌_등록(MultiPartSpecification multiPartSpecification, String name, String account, String token) {
+    public static ExtractableResponse<Response> 계좌_등록(MultiPartSpecification multiPartSpecification, String name, String account, String bank, String token) {
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(token)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .param("name", name)
-                .param("account", account)
+                .param("accountHolder", name)
+                .param("accountNumber", account)
+                .param("bank", bank)
                 .multiPart(multiPartSpecification)
                 .post("/members/me/account")
                 .then().extract()
@@ -325,12 +326,12 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder("testImageBinary".getBytes())
                 .mimeType(MimeTypeUtils.IMAGE_JPEG.toString())
-                .controlName("accountRegisterRequest")
+                .controlName("bankbookImage")
                 .fileName("bankbook.jpg")
                 .build();
 
         ExtractableResponse<Response> response = 계좌_등록(multiPartSpecification, "실명",
-                "1234-5678-1234", signUpResponse.getToken());
+                "1234-5678-1234", "은행", signUpResponse.getToken());
 
         assertThat(response.statusCode()).isEqualTo(200);
     }

--- a/server/src/test/java/com/example/tyfserver/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/controller/MemberControllerTest.java
@@ -766,7 +766,7 @@ class MemberControllerTest {
     @DisplayName("Post - /members/me/account - success")
     void registerAccount() throws Exception {
         //given
-        MockMultipartFile file = new MockMultipartFile("accountRegisterRequest", "testImage1.jpg",
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
                 ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
 
         //when
@@ -775,8 +775,9 @@ class MemberControllerTest {
         //then
         mockMvc.perform(multipart("/members/me/account")
                 .file(file)
-                .param("name", "test")
-                .param("account", "1234-5678-1234")
+                .param("accountHolder", "test")
+                .param("accountNumber", "1234-5678-1234")
+                .param("bank", "은행")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isOk())
                 .andDo(document("registerAccount",
@@ -785,10 +786,10 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("Post - /members/me/account - fail - account registered")
-    void registerAccountFailWhenAccountRegistered() throws Exception {
+    @DisplayName("Post - /members/me/account - fail - validation")
+    void registerAccountFailWhenInvalidValue() throws Exception {
         //given
-        MockMultipartFile file = new MockMultipartFile("accountRegisterRequest", "testImage1.jpg",
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
                 ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
 
         validInterceptorAndArgumentResolverMocking();
@@ -797,8 +798,33 @@ class MemberControllerTest {
         //when
         mockMvc.perform(multipart("/members/me/account")
                 .file(file)
-                .param("name", "test")
-                .param("account", "1234-5678-1234")
+                .param("accountHolder", "")
+                .param("accountNumber", "")
+                .param("bank", "")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode").value(AccountRegisterValidationRequestException.ERROR_CODE))
+                .andDo(document("registerAccountFailWhenInvalidValue",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())));
+    }
+
+    @Test
+    @DisplayName("Post - /members/me/account - fail - account registered")
+    void registerAccountFailWhenAccountRegistered() throws Exception {
+        //given
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
+                ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
+
+        validInterceptorAndArgumentResolverMocking();
+        doThrow(new AccountAlreadyRegisteredException()).when(memberService).registerAccount(Mockito.any(), Mockito.any());
+
+        //when
+        mockMvc.perform(multipart("/members/me/account")
+                .file(file)
+                .param("accountHolder", "test")
+                .param("accountNumber", "1234-5678-1234")
+                .param("bank", "은행")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(AccountAlreadyRegisteredException.ERROR_CODE))
@@ -811,7 +837,7 @@ class MemberControllerTest {
     @DisplayName("Post - /members/me/account - fail - account requesting")
     void registerAccountFailWhenAccountRequesting() throws Exception {
         //given
-        MockMultipartFile file = new MockMultipartFile("accountRegisterRequest", "testImage1.jpg",
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
                 ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
 
         validInterceptorAndArgumentResolverMocking();
@@ -820,8 +846,9 @@ class MemberControllerTest {
         //when
         mockMvc.perform(multipart("/members/me/account")
                 .file(file)
-                .param("name", "test")
-                .param("account", "1234-5678-1234")
+                .param("accountHolder", "test")
+                .param("accountNumber", "1234-5678-1234")
+                .param("bank", "은행")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(AccountRequestingException.ERROR_CODE))
@@ -834,7 +861,7 @@ class MemberControllerTest {
     @DisplayName("Post - /members/me/account - fail - authorization header not found")
     public void registerAccountHeaderNotFoundFailed() throws Exception {
         //given
-        MockMultipartFile file = new MockMultipartFile("accountRegisterRequest", "testImage1.jpg",
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
                 ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
 
         //when
@@ -843,8 +870,8 @@ class MemberControllerTest {
         //then
         mockMvc.perform(multipart("/members/me/account")
                 .file(file)
-                .param("name", "test")
-                .param("account", "1234-5678-1234")
+                .param("accountHolder", "test")
+                .param("accountNumber", "1234-5678-1234")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(AuthorizationHeaderNotFoundException.ERROR_CODE))
@@ -859,7 +886,7 @@ class MemberControllerTest {
     @DisplayName("Post - /members/me/account - fail invalid token")
     public void registerAccountInvalidTokenFailed() throws Exception {
         //given
-        MockMultipartFile file = new MockMultipartFile("accountRegisterRequest", "testImage1.jpg",
+        MockMultipartFile file = new MockMultipartFile("bankbookImage", "testImage1.jpg",
                 ContentType.IMAGE_JPEG.getMimeType(), "testImageBinary".getBytes());
 
         //when
@@ -868,8 +895,9 @@ class MemberControllerTest {
         //then
         mockMvc.perform(multipart("/members/me/account")
                 .file(file)
-                .param("name", "test")
-                .param("account", "1234-5678-1234")
+                .param("accountHolder", "test")
+                .param("accountNumber", "1234-5678-1234")
+                .param("bank", "은행")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(InvalidTokenException.ERROR_CODE))

--- a/server/src/test/java/com/example/tyfserver/member/domain/MemberTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/domain/MemberTest.java
@@ -121,11 +121,11 @@ public class MemberTest {
         member.registerAccount("테스트", "1234-5678-1234","하나", "https://test.com/test.png");
 
         //when
-        member.cancelAccount();
+        member.rejectAccount();
 
         //then
         Account memberAccount = member.getAccount();
-        assertThat(memberAccount.getStatus()).isEqualTo(AccountStatus.CANCELLED);
+        assertThat(memberAccount.getStatus()).isEqualTo(AccountStatus.REJECTED);
     }
 
     private Member generateMemberWithAccount() {

--- a/server/src/test/java/com/example/tyfserver/member/domain/MemberTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/domain/MemberTest.java
@@ -69,10 +69,12 @@ public class MemberTest {
     @DisplayName("계좌정보를 등록한다.")
     public void registerAccount() {
         //given
-        Member member = testMember();
-        member.addInitialAccount(new Account());
-        member.registerAccount("테스트", "1234-5678-1234", "하나", "https://test.com/test.png");
+        Member member = generateMemberWithAccount();
 
+        //when
+        member.registerAccount("테스트", "1234-5678-1234","하나", "https://test.com/test.png");
+
+        //then
         Account memberAccount = member.getAccount();
         assertThat(memberAccount.getStatus()).isEqualTo(AccountStatus.REQUESTING);
         assertThat(memberAccount.getAccountHolder()).isEqualTo("테스트");
@@ -86,12 +88,49 @@ public class MemberTest {
     @DisplayName("계좌정보가 등록요청 상태이면 새로 계좌를 등록하지 못한다.")
     public void registerAccountWhenRequesting() {
         //given
-        Member member = testMember();
-        member.addInitialAccount(new Account());
-        member.registerAccount("테스트", "1234-5678-1234", "https://test.com/test.png", "하나");
+        Member member = generateMemberWithAccount();
+        member.registerAccount("테스트", "1234-5678-1234","하나", "https://test.com/test.png");
 
         assertThatThrownBy(() -> member.registerAccount("테스트", "1234-5678-1234",
                 "하나", "https://test.com/test.png"))
                 .isExactlyInstanceOf(AccountRequestingException.class);
+    }
+
+
+    @Test
+    @DisplayName("계좌정보가 등록이 승인된다.")
+    public void approveAccount() {
+        //given
+        Member member = generateMemberWithAccount();
+        member.registerAccount("테스트", "1234-5678-1234","하나", "https://test.com/test.png");
+
+        //when
+        member.approveAccount();
+
+        //then
+        Account memberAccount = member.getAccount();
+        assertThat(memberAccount.getStatus()).isEqualTo(AccountStatus.REGISTERED);
+    }
+
+
+    @Test
+    @DisplayName("계좌정보가 등록이 반려된다.")
+    public void cancelAccount() {
+        //given
+        Member member = generateMemberWithAccount();
+        member.registerAccount("테스트", "1234-5678-1234","하나", "https://test.com/test.png");
+
+        //when
+        member.cancelAccount();
+
+        //then
+        Account memberAccount = member.getAccount();
+        assertThat(memberAccount.getStatus()).isEqualTo(AccountStatus.CANCELLED);
+    }
+
+    private Member generateMemberWithAccount() {
+        Member member = testMember();
+        member.addInitialAccount(new Account());
+        return member;
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
@@ -273,14 +273,15 @@ class MemberRepositoryImplTest {
         em.persist(member5);
         em.persist(member6);
 
-        em.persist(member1);
-        em.persist(member2);
-        em.persist(member3);
-        em.persist(member4);
-        em.persist(member5);
-        em.persist(member6);
-
         List<RequestingAccountResponse> requestingAccounts = memberRepository.findRequestingAccounts();
         assertThat(requestingAccounts).hasSize(3);
+        RequestingAccountResponse data = requestingAccounts.get(0);
+        assertThat(data.getEmail()).isEqualTo(member1.getEmail());
+        assertThat(data.getNickname()).isEqualTo(member1.getNickname());
+        assertThat(data.getPageName()).isEqualTo(member1.getPageName());
+        assertThat(data.getAccountHolder()).isEqualTo(member1.getAccount().getAccountHolder());
+        assertThat(data.getAccountNumber()).isEqualTo(member1.getAccount().getAccountNumber());
+        assertThat(data.getBank()).isEqualTo(member1.getAccount().getBank());
+        assertThat(data.getBankbookImageUrl()).isEqualTo(member1.getAccount().getBankbookUrl());
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
@@ -1,9 +1,11 @@
 package com.example.tyfserver.member.repository;
 
+import com.example.tyfserver.admin.dto.RequestingAccountResponse;
 import com.example.tyfserver.auth.domain.Oauth2Type;
 import com.example.tyfserver.common.config.JpaAuditingConfig;
 import com.example.tyfserver.donation.domain.Donation;
 import com.example.tyfserver.donation.domain.Message;
+import com.example.tyfserver.member.domain.Account;
 import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.domain.MemberTest;
 import com.example.tyfserver.member.dto.CurationsResponse;
@@ -36,6 +38,9 @@ class MemberRepositoryImplTest {
 
     @Autowired
     private PaymentRepository paymentRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
 
     private Member testMember1;
     private Member testMember2;
@@ -207,5 +212,75 @@ class MemberRepositoryImplTest {
                 new CurationsResponse("nick1", 1000L, "page1",
                         "https://cloudfront.net/profile1.png", "I am test")
         );
+    }
+
+
+    @Test
+    @DisplayName("정산 계좌 승인 요청 리스트를 얻어온다.")
+    public void findRequestingAccounts() {
+
+        Member member1 = new Member("email1", "nick1", "page1",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile1.png");
+
+        Account defaultAccount1 = new Account();
+        em.persist(defaultAccount1);
+        member1.addInitialAccount(defaultAccount1);
+        member1.registerAccount("테스트유저1", "1234-5678-1231",
+                "하나", "https://cloudfront.net/bankbook.png");
+
+        Member member2 = new Member("email2", "nick2", "page2",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile2.png");
+
+        Account defaultAccount2 = new Account();
+        em.persist(defaultAccount2);
+        member2.addInitialAccount(defaultAccount2);
+
+        Member member3 = new Member("email3", "nick3", "page3",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile3.png");
+
+        Account defaultAccount3 = new Account();
+        em.persist(defaultAccount3);
+        member3.addInitialAccount(defaultAccount3);
+        member3.registerAccount("테스트유저1", "1234-5678-1233",
+                "하나", "https://cloudfront.net/bankbook.png");
+
+        Member member4 = new Member("email4", "nick4", "page4",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile4.png");
+
+        Account defaultAccount4 = new Account();
+        em.persist(defaultAccount4);
+        member4.addInitialAccount(defaultAccount4);
+
+        Member member5 = new Member("email5", "nick5", "page5",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile5.png");
+
+        Account defaultAccount5 = new Account();
+        member5.addInitialAccount(defaultAccount5);
+        em.persist(defaultAccount5);
+        member5.registerAccount("테스트유저1", "1234-5678-1236",
+                "하나", "https://cloudfront.net/bankbook.png");
+
+        Member member6 = new Member("email6", "nick6", "page6",
+                Oauth2Type.GOOGLE, "https://cloudfront.net/profile6.png");
+        Account defaultAccount6 = new Account();
+        em.persist(defaultAccount6);
+        member6.addInitialAccount(defaultAccount6);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+        em.persist(member5);
+        em.persist(member6);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+        em.persist(member5);
+        em.persist(member6);
+
+        List<RequestingAccountResponse> requestingAccounts = memberRepository.findRequestingAccounts();
+        assertThat(requestingAccounts).hasSize(3);
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/repository/MemberRepositoryImplTest.java
@@ -273,15 +273,15 @@ class MemberRepositoryImplTest {
         em.persist(member5);
         em.persist(member6);
 
-        List<RequestingAccountResponse> requestingAccounts = memberRepository.findRequestingAccounts();
+        List<Member> requestingAccounts = memberRepository.findRequestingAccounts();
         assertThat(requestingAccounts).hasSize(3);
-        RequestingAccountResponse data = requestingAccounts.get(0);
-        assertThat(data.getEmail()).isEqualTo(member1.getEmail());
-        assertThat(data.getNickname()).isEqualTo(member1.getNickname());
-        assertThat(data.getPageName()).isEqualTo(member1.getPageName());
-        assertThat(data.getAccountHolder()).isEqualTo(member1.getAccount().getAccountHolder());
-        assertThat(data.getAccountNumber()).isEqualTo(member1.getAccount().getAccountNumber());
-        assertThat(data.getBank()).isEqualTo(member1.getAccount().getBank());
-        assertThat(data.getBankbookImageUrl()).isEqualTo(member1.getAccount().getBankbookUrl());
+        Member selectedMember = requestingAccounts.get(0);
+        assertThat(selectedMember.getEmail()).isEqualTo(member1.getEmail());
+        assertThat(selectedMember.getNickname()).isEqualTo(member1.getNickname());
+        assertThat(selectedMember.getPageName()).isEqualTo(member1.getPageName());
+        assertThat(selectedMember.getAccount().getAccountHolder()).isEqualTo(member1.getAccount().getAccountHolder());
+        assertThat(selectedMember.getAccount().getAccountNumber()).isEqualTo(member1.getAccount().getAccountNumber());
+        assertThat(selectedMember.getAccount().getBank()).isEqualTo(member1.getAccount().getBank());
+        assertThat(selectedMember.getAccount().getBankbookUrl()).isEqualTo(member1.getAccount().getBankbookUrl());
     }
 }

--- a/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
@@ -138,7 +138,7 @@ class MemberServiceTest {
 
         //when
         doNothing().when(s3Connector).delete(Mockito.anyString());
-        when(s3Connector.upload(file, "users/" + loginMember.getId() + "/profiles/")).thenReturn(uploadedImage);
+        when(s3Connector.uploadBankBook(file, loginMember.getId())).thenReturn(uploadedImage);
 
         //then
         assertThat(memberService.uploadProfile(file, loginMember)).usingRecursiveComparison()

--- a/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
@@ -138,7 +138,7 @@ class MemberServiceTest {
 
         //when
         doNothing().when(s3Connector).delete(Mockito.anyString());
-        when(s3Connector.uploadBankBook(file, loginMember.getId())).thenReturn(uploadedImage);
+        when(s3Connector.uploadProfile(file, loginMember.getId())).thenReturn(uploadedImage);
 
         //then
         assertThat(memberService.uploadProfile(file, loginMember)).usingRecursiveComparison()

--- a/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/member/service/MemberServiceTest.java
@@ -139,7 +139,7 @@ class MemberServiceTest {
 
         //when
         doNothing().when(s3Connector).delete(Mockito.anyString());
-        when(s3Connector.upload(file, loginMember.getId())).thenReturn(uploadedImage);
+        when(s3Connector.upload(file, "users/" + loginMember.getId() + "/profiles/")).thenReturn(uploadedImage);
 
         //then
         assertThat(memberService.uploadProfile(file, loginMember)).usingRecursiveComparison()


### PR DESCRIPTION
### 구현사항
- 계좌 등록 신청 승인 API
- 계좌 등록 신청 반려 API
- 등록 요청 계좌 조회 API
- 계좌 등록 요청 유효성 검증
- 해당 API에 대한 도메인, 레포, 서비스, 컨트롤러, 인수 테스트 작성

### 주의사항
아직 백오피스 로그인이 들어가 있지 않아 인수테스트에서 토큰인증은 하지 못했습니다.
어드민 인증을 뺀 기능 수행 에 대한 인수테스트만 현재 진행했습니다. 

### 삽질 (?)

계좌 등록 신청과 같은 경우 통장사본, 계좌번호, 계좌주(?), 은행을  "multipart/form-data" content type으로
묶어서 보내는데, 테스트에서는 한글이 깨집니다.
RestAssured에서  "multipart/form-data"  리퀘스트를 utf-8로 인코딩하는 방법을 찾아봤지만 결국 못찾았어요 ㅜ

다만 포스트맨으로 테스트 결과 한글이 잘 찍힙니다!!
```
2021-08-11 01:16:56.785 http-nio-8080-exec-5 15223 [DEBUG] [o.h.internal.util.EntityPrinter         ] : com.example.tyfserver.member.domain.Account
{createdAt=2021-08-11T01:16:29.416986, 
accountHolder=한글입니다., bank=한글은, bankbookUrl=uploadedBankBookUrl, 
id=1, accountNumber=1234-1234-1234, status=REQUESTING}
2021-08-11 01:16:56.785 http-nio-8080-exec-5 15223 [DEBUG] [org.hibernate.SQL  
```