### PR TITLE
임시

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           push: true # optional, default is false
           
           # List of tags
-          tags: main # ${{ steps.docker_meta.outputs.tags }}
+          tags: jho2301/tyf-client # ${{ steps.docker_meta.outputs.tags }}
           # List of metadata for an image
           labels: main # ${{ steps.docker_meta.outputs.labels }}
       - 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,5 +67,5 @@ jobs:
           script: |
             docker pull jho2301/tyf-client:main
             docker rm -f tyf-client
-            docker run --name tyf-client -p 80:80 -p 443:443 -v /etc/ssl:/etc/ssl jho2301/tyf-client:main
+            docker run --name tyf-client -p 80:80 -p 443:443 -v /etc/ssl:/etc/ssl -d jho2301/tyf-client:main
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,71 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI/CD for client
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  workflow_dispatch: 
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: jho2301/tyf-client
+          tag-semver: |
+            {{version}}
+            {{major}}.{{minor}}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}          
+      - 
+        name: Build and push Docker images
+        # You may pin to the exact commit or the version.
+        # uses: docker/build-push-action@1bc1040caef9e604eb543693ba89b5bf4fc80935
+        uses: docker/build-push-action@v2.6.1
+        with:
+          # Build's context is the set of files located in the specified PATH or URL
+          context: client
+          # Path to the Dockerfile
+          file: client/dockerfile
+          # List of target platforms for build
+          platforms: linux/amd64 # optional
+          # Push is a shorthand for --output=type=registry
+          push: true # optional, default is false
+          
+          # List of tags
+          tags: main # ${{ steps.docker_meta.outputs.tags }}
+          # List of metadata for an image
+          labels: main # ${{ steps.docker_meta.outputs.labels }}
+      - 
+        name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.REMOTE_IP }}
+          username: ${{ secrets.REMOTE_SSH_ID }}
+          key: ${{ secrets.REMOTE_SSH_KEY }}
+          port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            docker pull jho2301/tyf-client:main
+            docker rm -f tyf-client
+            docker run --name tyf-client -p 80:80 -p 443:443 -v /etc/ssl:/etc/ssl jho2301/tyf-client:main
+            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           push: true # optional, default is false
           
           # List of tags
-          tags: jho2301/tyf-client # ${{ steps.docker_meta.outputs.tags }}
+          tags: jho2301/tyf-client:main # ${{ steps.docker_meta.outputs.tags }}
           # List of metadata for an image
           labels: main # ${{ steps.docker_meta.outputs.labels }}
       - 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: deploy
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/client/src/service/hooks/useDonation.ts
+++ b/client/src/service/hooks/useDonation.ts
@@ -18,7 +18,10 @@ const useDonation = (creatorId: CreatorId) => {
     const { merchantUid } = await requestPayment({ amount, email, pageName });
     const { IMP } = window;
 
-    const accountId = 'imp61348931';
+    const prodAccountId = 'imp52497817';
+    const devAccountId = 'imp61348931';
+
+    const accountId = process.env.NODE_ENV === 'development' ? devAccountId : prodAccountId;
 
     IMP.init(accountId);
 
@@ -29,10 +32,6 @@ const useDonation = (creatorId: CreatorId) => {
       name: pageName,
       amount,
       buyer_email: email,
-      // buyer_name: '홍길동',
-      // buyer_tel: '010-4242-4242',
-      // buyer_addr: '서울특별시 강남구 신사동',
-      // buyer_postcode: '01181',
     };
 
     const IMPResponseHandler = async (response: IamportResponse) => {

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -5,6 +5,7 @@ spring:
   jpa:
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         format_sql: true
 
   profiles:


### PR DESCRIPTION
closed #265 

# 로그인 - 어드민 페이지 접속 API
## To-do List
* 서브모듈에 등록한 임의값과 비교
* 토큰 

### 1. 서브모듈에 등록한 임의값과 비교 
* 서브모듈에 임의의 값 admin의 id, password 값 저장  (
* AdminAccount가 @Value를 통해 각각의 값들 읽어옴 
* AdminService 단에서 로그인 폼으로 입력받은 `AdminLoginRequest` 값과 id, password가 일치한지 여부 파악하여 일치하는지 파악
	* 일치하지 않으면 `InvalidAdminException` 예외 발생 (**admin-001**)
* [POST] /admin/login  요청을 통해 admin 페이지의 accessToken을 발급받는다. 


## 결과 
![A9AC26AB-D07C-4B19-8412-185EE857993B](https://user-images.githubusercontent.com/47850258/128919388-1c4d6b49-cdb7-45c6-9f05-4790d025d5dc.png)
### [GET] /admin <— 임의로 테스트를 위해 만든 API  (실제 PR 요청시에는 해당 API는 없을 예정) 
![CC12D844-6253-4CC0-8398-4FAEFBF033CD](https://user-images.githubusercontent.com/47850258/128919403-3f929dad-c804-48fa-b70b-4cd7116fac22.png)

### 고민할 점 
* accessToken의 payload를 뭘로 줘야할까? 임의의 값을 넣다보니, payload에 넣을 값도 크게 의미가 없어짐 🥲 
* 다른 파라미터 주입받는 것 없이,  아래와 같이 (admin, tyf-admin)를 key, value로 값을 집어넣음. (어짜피 사용하지 않고있으니, 크게 의미는 없음, 추후 변경하면 될 것 같음)
![93426ACF-414E-466C-A609-0B8663DCAD00](https://user-images.githubusercontent.com/47850258/128919444-c7e5c311-34ac-4610-bf8e-8976626fef61.png)
* AdminInterceptor, AdminArgumentResolver는 어느 패키지에 두는게 좋을까? 
	* `admin.config` vs  `auth.config` 둘 중 하나로 가야할 것 같음. 
	* 참고로 interceptor 등록도 `AdminPrincipalConfig` 클래스를 만들어서 등록해주는게 좋을지, 아니면 기존의 AuthenticaionPrincipalConfig 클래스에 추가해주는게 좋을지 (현재는 후자의 방식으로 구현) 
	* admin 전용 interceptor의 구현은 아래의 이유로 만들어야할 것 같다. 
		* admin page의 login 요청을 제외하고는 토큰없이 접근할 수 없게 막아야함으로 
		* AuthenticationInterceptor의 기존 경로들과는 접근 권한이 다르기 때문에 별개의 admin 인터셉터가 필요하다고 생각함. 

## 제안할 점 
* admin 페이지 관련 요청들은 모두 `prefix`로 `/admin` 을 두는 것이 어떨까? 

## To-do List 
> 정산등록 되었는지 필드: isBankRegistered (boolean)

1. members/{pageName} 에 isBankRegistered 필드 추가
2. donation시 정산가능계정 등록여부 validation 추가
	1. member#validateRefundable 추가 
	2. PaymentService#createPayment에서 호출 
3. /members/me/에 isBankRegistered 추가하여, 정산가능계정인지 확인해서 정산관리url이 담긴 popup / snackbar로 알람
* /members/me/account는 정산 페이지에서 계좌정보 그릴 때 호출


## 문제점 
* `isBankRegistered` 를 Jackson은 `bankRegistered`로 자동으로 `is`를 skip 해버림
	* `isBankRegistered` —> `bankRegistered`로 변경 
* donation시 정산가능계정 등록여부 validation 추가 
	* * 해당 기능은 지금 만들기에는 문제가 많다.
	* 일단 기존 테스트가 다 깨짐 
		* Donation, Payment, Member AcceptanceTest 깨짐!
	* MemberService의 메서드도 하나 깨지기는 하지만… 이건 뭐 문제는 안됌
	* 특히 인수테스트 쪽은 답이 없음 (계좌 등록 승인(?)해주는 API를 만들어야 함)
	* 결론: `작업 단위가 크다고 생각됌.`
참고: [java:lombok 권남](https://kwonnam.pe.kr/wiki/java/lombok)

## 고민해볼 점
* 계좌를 등록하는 시점에는 account의 state를 AccountStatus.REQUESTING로 둔다. 
	* 등록 요청한 계좌를 승인해주는 API