### PR TITLE
환불API 인증번호 메일전송 요청시 검증 추가

### DIFF
--- a/server/src/main/java/com/example/tyfserver/donation/domain/DonationStatus.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/DonationStatus.java
@@ -1,7 +1,16 @@
 package com.example.tyfserver.donation.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum DonationStatus {
-    REFUNDABLE, EXCHANGEABLE, EXCHANGED, CANCELLED;
+    REFUNDABLE("환불가능"), EXCHANGEABLE("정산가능"), EXCHANGED("정산완료"), CANCELLED("취소됨");
+
+    private final String information;
+
+    DonationStatus(String information) {
+        this.information = information;
+    }
 
     public boolean isRefundable() {
         return this == REFUNDABLE;

--- a/server/src/main/java/com/example/tyfserver/donation/domain/DonationStatus.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/DonationStatus.java
@@ -2,4 +2,8 @@ package com.example.tyfserver.donation.domain;
 
 public enum DonationStatus {
     REFUNDABLE, EXCHANGEABLE, EXCHANGED, CANCELLED;
+
+    public boolean isRefundable() {
+        return this == REFUNDABLE;
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/AccountStatus.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/AccountStatus.java
@@ -1,5 +1,8 @@
 package com.example.tyfserver.member.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum AccountStatus {
     UNREGISTERED("미등록"), REGISTERED("등록완료"), REQUESTING("등록요청"), CANCELLED("등록반려");
 

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -75,18 +75,18 @@ public class Payment extends BaseTimeEntity {
         this.status = paymentStatus;
     }
 
+    public void updateRefundFailure(RefundFailure refundFailure) {
+        this.refundFailure = refundFailure;
+    }
+
     public void complete(PaymentInfo paymentInfo) {
         validatePaymentComplete(paymentInfo);
         this.impUid = paymentInfo.getImpUid();
         this.status = PaymentStatus.PAID;
     }
 
-    public void updateRefundFailure(RefundFailure refundFailure) {
-        this.refundFailure = refundFailure;
-    }
-
     private void validatePaymentComplete(PaymentInfo paymentInfo) {
-        if (!PaymentStatus.isPaid(paymentInfo.getStatus())) {
+        if (!paymentInfo.getStatus().isPaid()) {
             updateStatus(paymentInfo.getStatus());
             throw IllegalPaymentInfoException.from(ERROR_CODE_NOT_PAID, paymentInfo.getModule());
         }
@@ -101,7 +101,7 @@ public class Payment extends BaseTimeEntity {
     }
 
     private void validatePaymentCancel(PaymentInfo paymentInfo) {
-        if (!PaymentStatus.isCancelled(paymentInfo.getStatus())) {
+        if (paymentInfo.getStatus().isCancelled()) {
             updateStatus(paymentInfo.getStatus());
             throw IllegalPaymentInfoException.from(ERROR_CODE_NOT_CANCELLED, paymentInfo.getModule());
         }

--- a/server/src/main/java/com/example/tyfserver/payment/domain/PaymentStatus.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/PaymentStatus.java
@@ -10,11 +10,11 @@ public enum PaymentStatus {
         this.information = info;
     }
 
-    public static boolean isPaid(PaymentStatus paymentStatus) {
-        return paymentStatus.equals(PAID);
+    public boolean isPaid() {
+        return this == PAID;
     }
 
-    public static boolean isCancelled(PaymentStatus paymentStatus) {
-        return paymentStatus.equals(CANCELLED);
+    public boolean isCancelled() {
+        return this == CANCELLED;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/domain/PaymentStatus.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/PaymentStatus.java
@@ -1,5 +1,8 @@
 package com.example.tyfserver.payment.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum PaymentStatus {
     READY("미결제"), PENDING("결제대기중"), PAID("결제완료"), CANCELLED("결제취소"), FAILED("결제실패"),
     INVALID("위변조검증실패");

--- a/server/src/main/java/com/example/tyfserver/payment/exception/CannotRefundException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/CannotRefundException.java
@@ -1,0 +1,27 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+import com.example.tyfserver.donation.domain.DonationStatus;
+import com.example.tyfserver.payment.domain.PaymentStatus;
+
+public class CannotRefundException extends BaseException {
+
+    public static final String ERROR_CODE = "payment-013";
+    private static final String MESSAGE = "환불할 수 없는 결제 건입니다.";
+
+    public CannotRefundException(String message) {
+        super(ERROR_CODE, MESSAGE + message);
+    }
+
+    public CannotRefundException(DonationStatus donationStatus) {
+        this("후원이 " + donationStatus.getInformation() + "상태입니다.");
+    }
+
+    public CannotRefundException(PaymentStatus paymentStatus) {
+        this("결제가 " + paymentStatus.getInformation() + "상태입니다.");
+    }
+
+    public CannotRefundException() {
+        this(MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -20,6 +20,7 @@ import com.example.tyfserver.payment.domain.PaymentInfo;
 import com.example.tyfserver.payment.domain.PaymentServiceConnector;
 import com.example.tyfserver.payment.domain.RefundFailure;
 import com.example.tyfserver.payment.dto.*;
+import com.example.tyfserver.payment.exception.CannotRefundException;
 import com.example.tyfserver.payment.exception.CodeResendCoolTimeException;
 import com.example.tyfserver.payment.exception.PaymentNotFoundException;
 import com.example.tyfserver.payment.exception.RefundVerificationBlockedException;
@@ -89,11 +90,10 @@ public class PaymentService {
 
     private void validateStatus(Payment payment, Donation donation) {
         if (!payment.getStatus().isPaid()) {
-            throw new RuntimeException();
+            throw new CannotRefundException(payment.getStatus());
         }
-
         if (!donation.getStatus().isRefundable()) {
-            throw new RuntimeException();
+            throw new CannotRefundException(donation.getStatus());
         }
     }
 

--- a/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/controller/AdminControllerTest.java
@@ -50,8 +50,8 @@ class AdminControllerTest {
 
         //when //then
         mockMvc.perform(post("/admin/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").value("token"))
                 .andDo(print())
@@ -70,8 +70,8 @@ class AdminControllerTest {
 
         //when //then
         mockMvc.perform(post("/admin/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new AdminLoginRequest("id", "password"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("errorCode").value(InvalidAdminException.ERROR_CODE))
                 .andDo(print())

--- a/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/admin/service/AdminServiceTest.java
@@ -3,7 +3,6 @@ package com.example.tyfserver.admin.service;
 import com.example.tyfserver.admin.domain.AdminAccount;
 import com.example.tyfserver.admin.dto.AdminLoginRequest;
 import com.example.tyfserver.admin.exception.InvalidAdminException;
-import com.example.tyfserver.auth.dto.Oauth2Request;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
인증번호 전송 요청을 할 때 결제나 후원의 상태를 검증.
이미 환불됨, 결제 대기중 상태 등 환불이 불가하다면 예외 발생.