### PR TITLE
[#326] 후원 및 환불 api 리팩토링 및 구현

### DIFF
--- a/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
@@ -24,7 +24,6 @@ import java.time.format.DateTimeFormatter;
 public class SmtpMailConnector {
 
     private static final String PREFIX_SUBJECT = "[Thank You For]";
-    private static final String CREATOR_PREFIX_DOMAIN = "https://thankyou-for.com/creator/";
 
     private final JavaMailSender javaMailSender;
     private final TemplateEngine templateEngine;

--- a/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
@@ -71,18 +71,15 @@ public class SmtpMailConnector {
         sendMail("정산 계좌 승인 반려", message, mailAddress);
     }
 
-    public void sendChargeComplete(Payment payment, Member member) {
+    public void sendChargeComplete(Payment payment) {
         Context context = new Context();
-        context.setVariable("page_url", CREATOR_PREFIX_DOMAIN + payment.getItemName());
+        context.setVariable("item_name", payment.getItemName());
         context.setVariable("merchant_id", payment.getMerchantUid());
-        context.setVariable("creator_name", member.getNickname());
-        context.setVariable("donation_amount", payment.getAmount());
+        context.setVariable("charge_amount", payment.getAmount());
         context.setVariable("date",    payment.getCreatedAt().now().
                 format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 
-
-
-        String message = templateEngine.process("mail-donation-complete.html", context);
+        String message = templateEngine.process("mail-charge-complete.html", context);
         sendMail("후원 성공", message, payment.getEmail());
 
     }

--- a/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
+++ b/server/src/main/java/com/example/tyfserver/common/util/SmtpMailConnector.java
@@ -71,7 +71,7 @@ public class SmtpMailConnector {
         sendMail("정산 계좌 승인 반려", message, mailAddress);
     }
 
-    public void sendDonationComplete(Payment payment, Member member) {
+    public void sendChargeComplete(Payment payment, Member member) {
         Context context = new Context();
         context.setVariable("page_url", CREATOR_PREFIX_DOMAIN + payment.getItemName());
         context.setVariable("merchant_id", payment.getMerchantUid());

--- a/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
+++ b/server/src/main/java/com/example/tyfserver/donation/controller/DonationController.java
@@ -2,11 +2,11 @@ package com.example.tyfserver.donation.controller;
 
 import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.donation.dto.DonationMessageRequest;
+import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.exception.DonationMessageRequestException;
 import com.example.tyfserver.donation.exception.DonationRequestException;
 import com.example.tyfserver.donation.service.DonationService;
-import com.example.tyfserver.payment.dto.PaymentCompleteRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -24,14 +24,15 @@ public class DonationController {
 
     private final DonationService donationService;
 
-    //todo: 이 부분 완전 바뀌어야함
-//    @PostMapping
-//    public ResponseEntity<DonationResponse> createDonation(@Valid @RequestBody PaymentCompleteRequest paymentCompleteRequest, BindingResult result) {
-//        if (result.hasErrors()) {
-//            throw new DonationRequestException();
-//        }
-//        return ResponseEntity.status(HttpStatus.CREATED).body(donationService.createDonation(paymentCompleteRequest));
-//    }
+    @PostMapping
+    public ResponseEntity<DonationResponse> createDonation(@Valid @RequestBody DonationRequest donationRequest,
+                                                           BindingResult result, LoginMember loginMember) {
+        if (result.hasErrors()) {
+            throw new DonationRequestException();
+        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(donationService.createDonation(donationRequest, loginMember.getId()));
+    }
 
     @PostMapping("/{donationId}/messages")
     public ResponseEntity<Void> addDonationMessage(@PathVariable Long donationId,

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -1,7 +1,6 @@
 package com.example.tyfserver.donation.domain;
 
 import com.example.tyfserver.common.domain.BaseTimeEntity;
-import com.example.tyfserver.donation.exception.DonationAlreadyCancelledException;
 import com.example.tyfserver.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -28,9 +27,6 @@ public class Donation extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @Enumerated(value = EnumType.STRING)
-    private DonationStatus status = DonationStatus.REFUNDABLE;
 
     public Donation(Message message, long point) {
         this(null, message, point);
@@ -60,27 +56,5 @@ public class Donation extends BaseTimeEntity {
 
     public boolean isSecret() {
         return message.isSecret();
-    }
-
-    public void toCancelled() {
-        status = DonationStatus.CANCELLED;
-    }
-
-    public void toExchanged() {
-        status = DonationStatus.EXCHANGED;
-    }
-
-    public void toExchangeable() {
-        status = DonationStatus.EXCHANGEABLE;
-    }
-
-    public void validateIsNotCancelled() {
-        if (status == DonationStatus.CANCELLED) {
-            throw new DonationAlreadyCancelledException();
-        }
-    }
-
-    public boolean isNotRefundable() {
-        return status != DonationStatus.REFUNDABLE;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -32,22 +32,14 @@ public class Donation extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private DonationStatus status = DonationStatus.REFUNDABLE;
 
+    public Donation(Message message, long point) {
+        this(null, message, point);
+    }
+
     public Donation(Long id, Message message, long point) {
         this.id = id;
         this.message = message;
         this.point = point;
-    }
-
-    public Donation(long point) {
-        this(null, Message.defaultMessage(), point);
-    }
-
-    public Donation(Message message) {
-        this(null, message, 0L);
-    }
-
-    public Donation(Message message, long point) {
-        this(null, message, point);
     }
 
     public void to(final Member member) {

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Donation.java
@@ -1,6 +1,7 @@
 package com.example.tyfserver.donation.domain;
 
 import com.example.tyfserver.common.domain.BaseTimeEntity;
+import com.example.tyfserver.donation.exception.DonationAlreadyCancelledException;
 import com.example.tyfserver.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,6 +28,9 @@ public class Donation extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Enumerated(value = EnumType.STRING)
+    private DonationStatus status = DonationStatus.REFUNDABLE;
 
     public Donation(Message message, long point) {
         this(null, message, point);
@@ -56,5 +60,27 @@ public class Donation extends BaseTimeEntity {
 
     public boolean isSecret() {
         return message.isSecret();
+    }
+
+    public void toCancelled() {
+        status = DonationStatus.CANCELLED;
+    }
+
+    public void toExchanged() {
+        status = DonationStatus.EXCHANGED;
+    }
+
+    public void toExchangeable() {
+        status = DonationStatus.EXCHANGEABLE;
+    }
+
+    public void validateIsNotCancelled() {
+        if (status == DonationStatus.CANCELLED) {
+            throw new DonationAlreadyCancelledException();
+        }
+    }
+
+    public boolean isNotRefundable() {
+        return status != DonationStatus.REFUNDABLE;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/domain/DonationType.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/DonationType.java
@@ -1,0 +1,5 @@
+package com.example.tyfserver.donation.domain;
+
+public enum DonationType {
+    DONATED, DONATING;
+}

--- a/server/src/main/java/com/example/tyfserver/donation/domain/Message.java
+++ b/server/src/main/java/com/example/tyfserver/donation/domain/Message.java
@@ -11,7 +11,6 @@ import javax.persistence.Embeddable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message {
 
-    public static final String DEFAULT_NAME = "익명인";
     public static final String DEFAULT_MESSAGE = "당신을 응원합니다.";
     public static final String SECRET_NAME = "익명인";
     public static final String SECRET_MESSAGE = "비공개 메세지입니다.";
@@ -22,13 +21,13 @@ public class Message {
 
     private boolean secret;
 
+    public Message(String name) {
+        this(name, DEFAULT_MESSAGE, false);
+    }
+
     public Message(String name, String message, boolean secret) {
         this.name = name;
         this.message = message;
         this.secret = secret;
-    }
-
-    public static Message defaultMessage() {
-        return new Message(Message.DEFAULT_NAME, Message.DEFAULT_MESSAGE, false);
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/dto/DonationRequest.java
+++ b/server/src/main/java/com/example/tyfserver/donation/dto/DonationRequest.java
@@ -14,10 +14,10 @@ public class DonationRequest {
     @NotBlank
     private String pageName;
     @Positive
-    private Long donationAmount;
+    private Long point;
 
-    public DonationRequest(String pageName, Long donationAmount) {
+    public DonationRequest(String pageName, Long point) {
         this.pageName = pageName;
-        this.donationAmount = donationAmount;
+        this.point = point;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/donation/repository/DonationRepository.java
+++ b/server/src/main/java/com/example/tyfserver/donation/repository/DonationRepository.java
@@ -22,7 +22,8 @@ public interface DonationRepository extends JpaRepository<Donation, Long>, Donat
 
     List<Donation> findDonationByMemberAndStatusNotOrderByCreatedAtDesc(Member member, DonationStatus status, Pageable pageable);
 
-    Optional<Donation> findByPaymentId(Long id);
+    // todo
+//    Optional<Donation> findByPaymentId(Long id);
 
     @EntityGraph(attributePaths = "member")
     List<Donation> findDonationByStatusAndMember(DonationStatus status, Member member);

--- a/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
+++ b/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
@@ -1,18 +1,16 @@
 package com.example.tyfserver.donation.service;
 
-import com.example.tyfserver.common.util.SmtpMailConnector;
 import com.example.tyfserver.donation.domain.Donation;
 import com.example.tyfserver.donation.domain.DonationStatus;
+import com.example.tyfserver.donation.domain.Message;
 import com.example.tyfserver.donation.dto.DonationMessageRequest;
+import com.example.tyfserver.donation.dto.DonationRequest;
 import com.example.tyfserver.donation.dto.DonationResponse;
 import com.example.tyfserver.donation.exception.DonationNotFoundException;
 import com.example.tyfserver.donation.repository.DonationRepository;
 import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.example.tyfserver.member.repository.MemberRepository;
-import com.example.tyfserver.payment.domain.Payment;
-import com.example.tyfserver.payment.dto.PaymentCompleteRequest;
-import com.example.tyfserver.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,22 +26,21 @@ public class DonationService {
 
     private final DonationRepository donationRepository;
     private final MemberRepository memberRepository;
-    private final PaymentService paymentService;
-    private final SmtpMailConnector mailConnector;
 
-    //todo: 완전 바뀌어야할 로직
-//    public DonationResponse createDonation(PaymentCompleteRequest paymentCompleteRequest) {
-//        Payment payment = paymentService.completePayment(paymentCompleteRequest);
-//        Donation donation = new Donation(payment);
-//        Member member = memberRepository.findByPageName(payment.getItemName())
-//                .orElseThrow(MemberNotFoundException::new);
-//
-//        Donation savedDonation = donationRepository.save(donation);
-//        member.addDonation(savedDonation);
-//
-//        mailConnector.sendDonationComplete(payment, member);
-//        return new DonationResponse(savedDonation);
-//    }
+    public DonationResponse createDonation(DonationRequest donationRequest, long id) {
+        Member donator = findMember(id);
+        Member creator = memberRepository.findByPageName(donationRequest.getPageName())
+                .orElseThrow(MemberNotFoundException::new);
+
+        donator.validateEnoughPointToDonate(donationRequest.getPoint());
+
+        Message message = new Message(donator.getNickname());
+        Donation creatorDonation = new Donation(message, donationRequest.getPoint());
+        Donation savedDonation = donationRepository.save(creatorDonation);
+        creator.addDonation(savedDonation);
+
+        return new DonationResponse(savedDonation);
+    }
 
     public void addMessageToDonation(final Long donationId, final DonationMessageRequest donationMessageRequest) {
         Donation donation = donationRepository.findById(donationId)
@@ -53,12 +50,16 @@ public class DonationService {
     }
 
     public List<DonationResponse> findMyDonations(Long memberId, Pageable pageable) {
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member findMember = findMember(memberId);
 
         List<Donation> donations = donationRepository.findDonationByMemberAndStatusNotOrderByCreatedAtDesc(findMember, DonationStatus.CANCELLED, pageable);
 
         return privateDonationResponses(donations);
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
     }
 
     public List<DonationResponse> findPublicDonations(String pageName) {

--- a/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
+++ b/server/src/main/java/com/example/tyfserver/donation/service/DonationService.java
@@ -32,7 +32,7 @@ public class DonationService {
         Member creator = memberRepository.findByPageName(donationRequest.getPageName())
                 .orElseThrow(MemberNotFoundException::new);
 
-        donator.validateEnoughPointToDonate(donationRequest.getPoint());
+        donator.validateEnoughPoint(donationRequest.getPoint());
 
         Message message = new Message(donator.getNickname());
         Donation creatorDonation = new Donation(message, donationRequest.getPoint());

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -92,6 +92,10 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
+    public long getAvailablePoint() {
+        return this.availablePoint.getPoint();
+    }
+
     public long getDonatedPoint() {
         return this.donatedPoint.getPoint();
     }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -125,7 +125,7 @@ public class Member extends BaseTimeEntity {
         this.account.register(accountHolder, accountNumber, bank, bankBookUrl);
     }
 
-    public void validateEnoughPointToDonate(Long point) {
+    public void validateEnoughPoint(Long point) {
         if (availablePoint.lessThan(point)) {
             throw new NotEnoughPointException();
         }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -36,9 +36,11 @@ public class Member extends BaseTimeEntity {
     private String profileImage;
 
     @Embedded
+    @AttributeOverride(name = "point", column = @Column(name = "available_point"))
     private Point availablePoint;
 
     @Embedded
+    @AttributeOverride(name = "point", column = @Column(name = "donated_point"))
     private Point donatedPoint;
 
     @Enumerated(EnumType.STRING)

--- a/server/src/main/java/com/example/tyfserver/member/domain/Member.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.example.tyfserver.member.domain;
 import com.example.tyfserver.auth.domain.Oauth2Type;
 import com.example.tyfserver.common.domain.BaseTimeEntity;
 import com.example.tyfserver.donation.domain.Donation;
+import com.example.tyfserver.member.exception.NotEnoughPointException;
 import com.example.tyfserver.payment.domain.Payment;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -122,6 +123,12 @@ public class Member extends BaseTimeEntity {
 
     public void registerAccount(String accountHolder, String accountNumber, String bank, String bankBookUrl) {
         this.account.register(accountHolder, accountNumber, bank, bankBookUrl);
+    }
+
+    public void validateEnoughPointToDonate(Long point) {
+        if (availablePoint.lessThan(point)) {
+            throw new NotEnoughPointException();
+        }
     }
 
     public AccountStatus getAccountStatus() {

--- a/server/src/main/java/com/example/tyfserver/member/domain/Point.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Point.java
@@ -28,4 +28,8 @@ public class Point {
         }
         this.point -= amount;
     }
+
+    public boolean lessThan(Long point) {
+        return this.point < point;
+    }
 }

--- a/server/src/main/java/com/example/tyfserver/member/domain/Point.java
+++ b/server/src/main/java/com/example/tyfserver/member/domain/Point.java
@@ -1,5 +1,6 @@
 package com.example.tyfserver.member.domain;
 
+import com.example.tyfserver.member.exception.NotEnoughPointException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +25,7 @@ public class Point {
 
     public void reduce(final long amount) {
         if (amount > point) {
-            throw new RuntimeException("포인트가 총액보다 적게 있습니다.");
+            throw new NotEnoughPointException();
         }
         this.point -= amount;
     }

--- a/server/src/main/java/com/example/tyfserver/member/dto/MemberResponse.java
+++ b/server/src/main/java/com/example/tyfserver/member/dto/MemberResponse.java
@@ -15,23 +15,26 @@ public class MemberResponse {
     private String pageName;
     private String bio;
     private String profileImage;
+    private long point;
     private boolean bankRegistered;
 
     public MemberResponse(Member member) {
         this(member.getEmail(), member.getNickname(), member.getPageName(),
-                member.getBio(), member.getProfileImage(), isBankRegistered(member));
+                member.getBio(), member.getProfileImage(), member.getAvailablePoint(), isBankRegistered(member));
     }
 
     private static boolean isBankRegistered(Member member) {
         return member.getAccountStatus() == AccountStatus.REGISTERED;
     }
 
-    public MemberResponse(String email, String nickname, String pageName, String bio, String profileImage, boolean bankRegistered) {
+    public MemberResponse(String email, String nickname, String pageName, String bio,
+                          String profileImage, long point, boolean bankRegistered) {
         this.email = email;
         this.nickname = nickname;
         this.pageName = pageName;
         this.bio = bio;
         this.profileImage = profileImage;
+        this.point = point;
         this.bankRegistered = bankRegistered;
     }
 }

--- a/server/src/main/java/com/example/tyfserver/member/exception/NotEnoughPointException.java
+++ b/server/src/main/java/com/example/tyfserver/member/exception/NotEnoughPointException.java
@@ -5,7 +5,7 @@ import com.example.tyfserver.common.exception.BaseException;
 public class NotEnoughPointException extends BaseException {
 
     public static final String ERROR_CODE = "donation-010";
-    private static final String MESSAGE = "보유 포인트가 후원하려는 포인트보다 낮습니다.";
+    private static final String MESSAGE = "보유 포인트가 충분하지 않습니다.";
 
     public NotEnoughPointException() {
         super(ERROR_CODE, MESSAGE);

--- a/server/src/main/java/com/example/tyfserver/member/exception/NotEnoughPointException.java
+++ b/server/src/main/java/com/example/tyfserver/member/exception/NotEnoughPointException.java
@@ -1,0 +1,13 @@
+package com.example.tyfserver.member.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class NotEnoughPointException extends BaseException {
+
+    public static final String ERROR_CODE = "donation-010";
+    private static final String MESSAGE = "보유 포인트가 후원하려는 포인트보다 낮습니다.";
+
+    public NotEnoughPointException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/controller/PaymentController.java
+++ b/server/src/main/java/com/example/tyfserver/payment/controller/PaymentController.java
@@ -3,11 +3,13 @@ package com.example.tyfserver.payment.controller;
 import com.example.tyfserver.auth.dto.LoginMember;
 import com.example.tyfserver.auth.dto.VerifiedRefunder;
 import com.example.tyfserver.payment.dto.*;
+import com.example.tyfserver.payment.exception.PaymentCompleteRequestException;
 import com.example.tyfserver.payment.exception.PaymentPendingRequestException;
 import com.example.tyfserver.payment.exception.RefundVerificationException;
 import com.example.tyfserver.payment.exception.RefundVerificationReadyException;
 import com.example.tyfserver.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -21,8 +23,7 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
-    //todo: /payments 에서 /charge/ready 쪽으로 옮겨가야됨. PaymentController 네이밍이 ChargeController로 바뀔지도?
-    @PostMapping
+    @PostMapping("/charge/ready")
     public ResponseEntity<PaymentPendingResponse> payment(@Valid @RequestBody PaymentPendingRequest paymentPendingRequest, BindingResult result,
                                                           LoginMember loginMember) {
         if (result.hasErrors()) {
@@ -31,6 +32,16 @@ public class PaymentController {
 
         PaymentPendingResponse response = paymentService.createPayment(paymentPendingRequest.getItemId(), loginMember);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/charge")
+    public ResponseEntity<PaymentCompleteResponse> completePayment(@Valid @RequestBody PaymentCompleteRequest paymentCompleteRequest, BindingResult result) {
+        if (result.hasErrors()) {
+            throw new PaymentCompleteRequestException();
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(paymentService.completePayment(paymentCompleteRequest));
     }
 
     @PostMapping("/refund/verification/ready")

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Item.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Item.java
@@ -1,0 +1,37 @@
+package com.example.tyfserver.payment.domain;
+
+import com.example.tyfserver.payment.exception.ItemNotFoundException;
+
+import java.util.Arrays;
+
+public enum Item {
+    ITEM_1("1000포인트 충전", 1000L),
+    ITEM_3("3000포인트 충전", 3000L),
+    ITEM_5("5000포인트 충전", 5000L),
+    ITEM_10("10000포인트 충전", 10000L),
+    ITEM_50("50000포인트 충전", 50000L),
+    ITEM_100("100000포인트 충전", 100000L);
+
+    private String itemName;
+    private long itemPrice;
+
+    Item(String itemName, long itemPrice) {
+        this.itemName = itemName;
+        this.itemPrice = itemPrice;
+    }
+
+    public static Item findItem(String itemId) {
+        return Arrays.stream(Item.values())
+                .filter(item -> item.name().equals(itemId))
+                .findAny()
+                .orElseThrow(ItemNotFoundException::new);
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public long getItemPrice() {
+        return itemPrice;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -104,6 +104,7 @@ public class Payment extends BaseTimeEntity {
         validatePaymentCancel(paymentInfo);
         this.impUid = paymentInfo.getImpUid();
         this.status = PaymentStatus.CANCELLED;
+        member.reducePoint(amount);
     }
 
     private void validatePaymentCancel(PaymentInfo paymentInfo) {

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -170,10 +170,11 @@ public class Payment extends BaseTimeEntity {
     }
 
     public boolean isAfterRefundGuaranteeDuration() {
-        return LocalDateTime.now().isAfter(getCreatedAt().plusDays(7));
+        return LocalDateTime.now()
+                .isAfter(getCreatedAt().plusDays(7));
     }
 
-    public void validateMemberHasEnoughPoint() {
+    public void validateMemberHasRefundablePoint() {
         member.validateEnoughPoint(amount);
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import static com.example.tyfserver.payment.exception.IllegalPaymentInfoException.*;
@@ -170,8 +170,10 @@ public class Payment extends BaseTimeEntity {
     }
 
     public boolean isAfterRefundGuaranteeDuration() {
-        return LocalDateTime.now()
-                .isAfter(getCreatedAt().plusDays(7));
+        LocalDate createdDate = getCreatedAt().toLocalDate();
+        LocalDate nowDate = LocalDate.now();
+
+        return nowDate.isAfter(createdDate.plusDays(6));
     }
 
     public void validateMemberHasRefundablePoint() {

--- a/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
+++ b/server/src/main/java/com/example/tyfserver/payment/domain/Payment.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static com.example.tyfserver.payment.exception.IllegalPaymentInfoException.*;
@@ -165,5 +166,13 @@ public class Payment extends BaseTimeEntity {
 
     public boolean isNotPaid() {
         return status != PaymentStatus.PAID;
+    }
+
+    public boolean isAfterRefundGuaranteeDuration() {
+        return LocalDateTime.now().isAfter(getCreatedAt().plusDays(7));
+    }
+
+    public void validateMemberHasEnoughPoint() {
+        member.validateEnoughPoint(amount);
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/dto/PaymentCompleteResponse.java
+++ b/server/src/main/java/com/example/tyfserver/payment/dto/PaymentCompleteResponse.java
@@ -1,0 +1,16 @@
+package com.example.tyfserver.payment.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentCompleteResponse {
+
+    private long point;
+
+    public PaymentCompleteResponse(long point) {
+        this.point = point;
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/dto/RefundInfoResponse.java
+++ b/server/src/main/java/com/example/tyfserver/payment/dto/RefundInfoResponse.java
@@ -1,6 +1,5 @@
 package com.example.tyfserver.payment.dto;
 
-import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.payment.domain.Payment;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
@@ -13,51 +12,19 @@ import java.time.LocalDateTime;
 @Getter
 public class RefundInfoResponse {
 
-    private CreatorInfoResponse creator;
-    private PaymentInfoResponse payment;
+    private Long amount;
+    private String itemName;
 
-    public RefundInfoResponse(CreatorInfoResponse creator, PaymentInfoResponse payment) {
-        this.creator = creator;
-        this.payment = payment;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy'/'MM'/'dd'/' HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    public RefundInfoResponse(Long amount, LocalDateTime createdAt, String itemName) {
+        this.amount = amount;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
     }
 
-    public RefundInfoResponse(Payment payment, Member member) {
-        this(new CreatorInfoResponse(member), new PaymentInfoResponse(payment));
-    }
-
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @Getter
-    public static class CreatorInfoResponse {
-
-        private String nickname;
-        private String pageName;
-
-        public CreatorInfoResponse(String nickname, String pageName) {
-            this.nickname = nickname;
-            this.pageName = pageName;
-        }
-
-        public CreatorInfoResponse(Member member) {
-            this(member.getNickname(), member.getPageName());
-        }
-    }
-
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @Getter
-    public static class PaymentInfoResponse {
-
-        private Long amount;
-
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy'/'MM'/'dd'/' HH:mm:ss", timezone = "Asia/Seoul")
-        private LocalDateTime createdAt;
-
-        public PaymentInfoResponse(Long amount, LocalDateTime createdAt) {
-            this.amount = amount;
-            this.createdAt = createdAt;
-        }
-
-        public PaymentInfoResponse(Payment payment) {
-            this(payment.getAmount(), payment.getCreatedAt());
-        }
+    public RefundInfoResponse(Payment payment) {
+        this(payment.getAmount(), payment.getCreatedAt(), payment.getItemName());
     }
 }

--- a/server/src/main/java/com/example/tyfserver/payment/exception/ItemNotFoundException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/ItemNotFoundException.java
@@ -1,0 +1,13 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class ItemNotFoundException extends BaseException {
+
+    public static final String ERROR_CODE = "payment-014";
+    private static final String MESSAGE = "존재하지 않는 ItemId 입니다.";
+
+    public ItemNotFoundException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/exception/PaymentCompleteRequestException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/PaymentCompleteRequestException.java
@@ -1,0 +1,13 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class PaymentCompleteRequestException extends BaseException {
+
+    public static final String ERROR_CODE = "payment-015";
+    private static final String MESSAGE = "Payment 확정 시에 넘기는 Request의 값이 유효한 값이 아닙니다.";
+
+    public PaymentCompleteRequestException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/exception/RefundGuaranteeDurationException.java
+++ b/server/src/main/java/com/example/tyfserver/payment/exception/RefundGuaranteeDurationException.java
@@ -1,0 +1,13 @@
+package com.example.tyfserver.payment.exception;
+
+import com.example.tyfserver.common.exception.BaseException;
+
+public class RefundGuaranteeDurationException extends BaseException {
+
+    public static final String ERROR_CODE = "refund-003";
+    private static final String MESSAGE = "환불 기간이 지났습니다.";
+
+    public RefundGuaranteeDurationException() {
+        super(ERROR_CODE, MESSAGE);
+    }
+}

--- a/server/src/main/java/com/example/tyfserver/payment/repository/PaymentRepository.java
+++ b/server/src/main/java/com/example/tyfserver/payment/repository/PaymentRepository.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
+    @EntityGraph(attributePaths = {"member"})
     Optional<Payment> findByMerchantUid(UUID merchantUid);
 
     @EntityGraph(attributePaths = {"refundFailure"})

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -10,7 +10,6 @@ import com.example.tyfserver.auth.repository.CodeResendCoolTimeRepository;
 import com.example.tyfserver.auth.repository.VerificationCodeRepository;
 import com.example.tyfserver.auth.service.AuthenticationService;
 import com.example.tyfserver.common.util.SmtpMailConnector;
-import com.example.tyfserver.donation.repository.DonationRepository;
 import com.example.tyfserver.member.domain.Member;
 import com.example.tyfserver.member.exception.MemberNotFoundException;
 import com.example.tyfserver.member.repository.MemberRepository;
@@ -32,7 +31,6 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final MemberRepository memberRepository;
-    private final DonationRepository donationRepository;
     private final RefundFailureRepository refundFailureRepository;
 
     private final PaymentServiceConnector paymentServiceConnector;

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -62,6 +62,8 @@ public class PaymentService {
 
         Payment payment = findPayment(merchantUid);
         payment.complete(paymentInfo);
+        //todo: html 변경 후 적용
+//        smtpMailConnector.sendChargeComplete(payment);
         return new PaymentCompleteResponse(payment.getAmount());
     }
 

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -89,7 +89,7 @@ public class PaymentService {
         if (payment.isAfterRefundGuaranteeDuration()) {
             throw new RefundGuaranteeDurationException();
         }
-        payment.validateMemberHasEnoughPoint();
+        payment.validateMemberHasRefundablePoint();
     }
 
     private Integer checkResendCoolTime(String merchantUid) {

--- a/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
+++ b/server/src/main/java/com/example/tyfserver/payment/service/PaymentService.java
@@ -59,8 +59,7 @@ public class PaymentService {
 
         Payment payment = findPayment(merchantUid);
         payment.complete(paymentInfo);
-        //todo: html 변경 후 적용
-//        smtpMailConnector.sendChargeComplete(payment);
+        smtpMailConnector.sendChargeComplete(payment);
         return new PaymentCompleteResponse(payment.getAmount());
     }
 

--- a/server/src/main/resources/templates/mail-charge-complete.html
+++ b/server/src/main/resources/templates/mail-charge-complete.html
@@ -54,8 +54,8 @@
             </tr>
             <tr align="center">
               <td id="merchant-id"><span th:text="${merchant_id}"></span></td>
-              <td id="creator-name"><a th:href="${page_url}"><span th:text="${creator_name}"></span></a></td>
-              <td id="donation-amount"><span th:text="${donation_amount}"></span></td>
+              <td id="item-name"><span th:text="${item_name}"></span></a></td>
+              <td id="charge-amount"><span th:text="${charge_amount}"></span></td>
               <td id="date"><span th:text="${date}"></span></td>
             </tr>
           </table>

--- a/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
+++ b/server/src/test/java/com/example/tyfserver/donation/service/DonationServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -64,7 +63,7 @@ class DonationServiceTest {
         paymentRepository.save(payment);
         memberRepository.save(member);
         donationRepository.save(donation);
-        doNothing().when(mailConnector).sendDonationComplete(any(), any());
+        doNothing().when(mailConnector).sendChargeComplete(any(), any());
     }
 
     @AfterEach


### PR DESCRIPTION
## 포인트 충전 api 절차  

### /payments/charge/ready 

request: itemId
response : merchantUid, itemName, amount, email  

### /payments/charge

request : impUid, merchantUid  
response : point  

<br/>

## 후원 절차  

### /donations

request : pageName, point  
response : donationId, name, message, amount, createdAt  

### /donations/{donationId}/message

request : name, message, secret  
response : -  

환불은 내부로직만 바뀌고 엔드포인트 바뀐 것 없음  

<br/>

본인이 보낸 후원을 나중에 볼 수 있게끔 하기위해서 ``Donation``에 ``DonationType`` 이라는 enum 타입 필드를 추가해주고,  
후원 요청 시에 2개의 ``Donation``을 각각 만들어서 creator와 donator가 가지고 있는 List<Donation>에 집어넣어줬을 경우,  
``/donations/{donationId}/message`` 호출 시에 하나의 ``donationId`` 만 들어올텐데 두 도네이션의 ``Message``를 다 업데이트 하기가 애매한 것 같음!  
후원자가 본인이 보낸 후원 메세지에 대한 정보가 defaultMessage 여도 상관없다면 괜찮지만... 아니면 프론트한테 ``/donations`` 이후에 response 로 donationId를 2개를 response 해주고 message API 에서 2개의 id를 모두 받는 방법도 있긴하지만!  

<br/>

1. 이제 거의 모든 API가 토큰이 필요할텐데 (다 인가??) 인수테스트 짜는 담당이 이거 path 좀 config에 추가해줄레?  
2. ``Payment`` 환불 시에 환불 기간 지났는지에 대한 로직을  
![image](https://user-images.githubusercontent.com/45073750/132115178-b97c22e8-5035-4290-b7f2-2a7f177784e5.png)  
이걸로 짰는데 테스트 잊으면 안됑!  
3. 이전에는 후원하는 절차에서 결제를 했어서 그때 메일이 발송됐는데, 후원시에는 발송안하고 포인트 충전하면 발송하게끔 해놨어
4. Donation에 들어가는 Message 로직을 좀 바꿔놨어! 이제 ``defaultName``이 후원자의 nickname이니깐 이 부분 때문에 생성자가 바뀌었을거야 !! 

더 말할게 있었던 것 같은데 . .. 기억안나네... 일단 바뀐점 보면서 궁금한거 다 물어봐!!  
내가 놓친부분이 무조건 있을 것 같은데, 아마 테스트 짜면서 속속들이 발견될 것 같음 . . !!  

