### PR TITLE
feat(client): 도네이션 메세지폼, 닉네임 고정 처리

### DIFF
--- a/client/main/src/components/Donation/MessageForm/DonationMessageForm.tsx
+++ b/client/main/src/components/Donation/MessageForm/DonationMessageForm.tsx
@@ -3,6 +3,7 @@ import { FormEvent } from 'react';
 import { MAX_MESSAGE_LENGTH } from '../../../constants/donation';
 import useDonationMessage from '../../../service//donation/useDonationMessage';
 import useDonationMessageForm from '../../../service//donation/useDonationMessageForm';
+import useUserInfo from '../../../service/user/useUserInfo';
 import { CreatorId } from '../../../types';
 import Checkbox from '../../@atom/Checkbox/Checkbox';
 import Textarea from '../../@atom/Textarea/Textarea';
@@ -20,13 +21,14 @@ export interface DonationMessageFormProps {
 }
 
 const DonationMessageForm = ({ creatorId }: DonationMessageFormProps) => {
-  const { form, isPrivate, setMessage, setName, setIsPrivate } = useDonationMessageForm();
+  const { form, isPrivate, setMessage, setIsPrivate } = useDonationMessageForm();
   const { sendDonationMessage } = useDonationMessage(creatorId);
+  const { userInfo } = useUserInfo();
 
   const onSubmitMessage = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    sendDonationMessage(form.name, form.message, isPrivate);
+    sendDonationMessage(form.message, isPrivate);
   };
 
   return (
@@ -36,12 +38,7 @@ const DonationMessageForm = ({ creatorId }: DonationMessageFormProps) => {
         <br /> 응원의 한마디를
         <br /> 남겨주세요!
       </DonationMessageTitle>
-      <NickNameInput
-        aria-label="nickname"
-        placeholder="닉네임 입력하기"
-        value={form.name}
-        onChange={({ target }) => setName(target.value)}
-      />
+      <NickNameInput aria-label="nickname" value={userInfo?.nickname ?? ''} readOnly />
       <Textarea
         aria-label="message"
         placeholder="응원메세지 작성하기"

--- a/client/main/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.tsx
+++ b/client/main/src/components/Settlement/Info/Desktop/DesktopSettlementInfo.tsx
@@ -34,7 +34,7 @@ const DesktopSettlementInfo = () => {
           <span>
             <Amount>{toCommaSeparatedString(exchangeablePoint ?? 0)}</Amount>원
           </span>
-          <Caution>오늘 요청시 환급일 2021/{nextMonth}/28</Caution>
+          <Caution>오늘 요청시 환급일 2021 / {nextMonth} / 7</Caution>
         </AmountContainer>
         <Button onClick={applySettlement}>정산 신청하기</Button>
       </InfoContainer>

--- a/client/main/src/components/Settlement/Info/Mobile/MobileSettlementInfo.tsx
+++ b/client/main/src/components/Settlement/Info/Mobile/MobileSettlementInfo.tsx
@@ -34,7 +34,7 @@ const MobileSettlementInfo = () => {
           <AmountContainer>
             <Amount>{toCommaSeparatedString(exchangeablePoint ?? 0)}</Amount>원
           </AmountContainer>
-          <Caution>오늘 요청시 환급일 2021/{nextMonth}/28</Caution>
+          <Caution>오늘 요청시 환급일 2021 / {nextMonth} / 7</Caution>
         </InfoContainer>
         <InfoContainer>
           <StyledSubTitle>현재까지 정산 받은 금액은</StyledSubTitle>

--- a/client/main/src/service/donation/useDonation.ts
+++ b/client/main/src/service/donation/useDonation.ts
@@ -14,9 +14,9 @@ const useDonation = () => {
   const donate = async (creatorId: CreatorId, donationAmount: number) => {
     try {
       const result = await requestDonation(creatorId, donationAmount, accessToken);
-      const { donationId, message, amount } = result;
+      const { donationId, message, amount, name } = result;
 
-      setDonation({ ...donation, donationId, amount, message });
+      setDonation({ ...donation, donationId, amount, name, message });
 
       history.push(`/donation/${creatorId}/message`);
     } catch (error) {

--- a/client/main/src/service/donation/useDonationMessage.ts
+++ b/client/main/src/service/donation/useDonationMessage.ts
@@ -9,12 +9,13 @@ const useDonationMessage = (creatorId: CreatorId) => {
   const donation = useRecoilValue(donationState);
   const history = useHistory();
 
-  const sendDonationMessage = async (name: string, message: string, isSecret: boolean) => {
-    const finalName = name || donation.name;
+  const sendDonationMessage = async (message: string, isSecret: boolean) => {
     const finalMessage = message || donation.message;
 
+    console.dir(donation);
+
     try {
-      await requestSendDonationMessage(donation.donationId, finalName, finalMessage, isSecret);
+      await requestSendDonationMessage(donation.donationId, donation.name, finalMessage, isSecret);
 
       history.push(`/donation/${creatorId}/success`);
     } catch (error) {

--- a/client/main/src/service/donation/useDonationMessageForm.ts
+++ b/client/main/src/service/donation/useDonationMessageForm.ts
@@ -4,7 +4,7 @@ import { MAX_MESSAGE_LENGTH } from '../../constants/donation';
 import { DonationMessage } from '../../types';
 
 const useDonationMessageForm = () => {
-  const [form, setForm] = useState<DonationMessage>({ name: '', message: '' });
+  const [form, setForm] = useState<DonationMessage>({ message: '' });
   const [isPrivate, setIsPrivate] = useState(false);
 
   const setMessage = (message: string) => {
@@ -13,11 +13,7 @@ const useDonationMessageForm = () => {
     setForm({ ...form, message });
   };
 
-  const setName = (name: string) => {
-    setForm({ ...form, name });
-  };
-
-  return { form, isPrivate, setMessage, setName, setIsPrivate };
+  return { form, isPrivate, setMessage, setIsPrivate };
 };
 
 export default useDonationMessageForm;

--- a/client/main/src/types.ts
+++ b/client/main/src/types.ts
@@ -41,7 +41,7 @@ export interface Donation {
   createdAt: Date;
 }
 
-export type DonationMessage = Pick<Donation, 'name' | 'message'>;
+export type DonationMessage = Pick<Donation, 'message'>;
 
 // PAYMENT
 


### PR DESCRIPTION
1. 관련 로직 제거

2. 메세지 POST 요청의 닉네임 값은 POST donation으로 받아온 닉네임을 다시 보내도록 설정
    - 추후에 API를 변경하면 같이 변경하면 좋을듯!