### PR TITLE
refactor(server): 테스트 시간을 단축한다 (DirtiesContext 사용하지 않도록)

### DIFF
--- a/server/src/main/java/com/example/tyfserver/DatabaseCleanup.java
+++ b/server/src/main/java/com/example/tyfserver/DatabaseCleanup.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -23,11 +24,10 @@ public class DatabaseCleanup implements InitializingBean {
         this.entityManager = entityManager;
     }
 
-
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         tableNames = entityManager.getMetamodel().getEntities().stream()
-                .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                .filter(e -> Objects.nonNull(e.getJavaType().getAnnotation(Entity.class)))
                 .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
                 .collect(Collectors.toList());
     }
@@ -37,7 +37,7 @@ public class DatabaseCleanup implements InitializingBean {
         entityManager.flush();
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
-        for (String tableName: tableNames) {
+        for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE  TABLE " + tableName).executeUpdate();
             entityManager.createNativeQuery("ALTER  TABLE " + tableName +
                     " ALTER  COLUMN  ID RESTART  WITH  1").executeUpdate();

--- a/server/src/main/java/com/example/tyfserver/DatabaseCleanup.java
+++ b/server/src/main/java/com/example/tyfserver/DatabaseCleanup.java
@@ -1,0 +1,48 @@
+package com.example.tyfserver;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Profile("test")
+public class DatabaseCleanup implements InitializingBean {
+
+    private final EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    public DatabaseCleanup(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void cleanUp() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName: tableNames) {
+            entityManager.createNativeQuery("TRUNCATE  TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER  TABLE " + tableName +
+                    " ALTER  COLUMN  ID RESTART  WITH  1").executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
@@ -12,6 +12,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -24,12 +25,14 @@ import java.util.UUID;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 public class AcceptanceTest {
 
     @LocalServerPort
     private int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
 
     @MockBean
     private Oauth2ServiceConnector oauth2ServiceConnector;
@@ -46,6 +49,7 @@ public class AcceptanceTest {
     @BeforeEach
     protected void setUp() {
         RestAssured.port = port;
+        databaseCleanup.cleanUp();
         when(oauth2ServiceConnector.getEmailFromOauth2(any(), any()))
                 .thenReturn(DEFAULT_EMAIL);
         when(s3Connector.uploadBankBook(any(), any()))

--- a/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
+++ b/server/src/test/java/com/example/tyfserver/AcceptanceTest.java
@@ -17,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;

--- a/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
+++ b/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
@@ -27,8 +27,8 @@ public class DatabaseCleanup implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         tableNames = entityManager.getMetamodel().getEntities().stream()
-                .filter(e -> Objects.nonNull(e.getJavaType().getAnnotation(Entity.class)))
-                .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+                .filter(entity -> Objects.nonNull(entity.getJavaType().getAnnotation(Entity.class)))
+                .map(entity -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, entity.getName()))
                 .collect(Collectors.toList());
     }
 

--- a/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
+++ b/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
-@Profile("test")
 public class DatabaseCleanup implements InitializingBean {
 
     private final EntityManager entityManager;

--- a/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
+++ b/server/src/test/java/com/example/tyfserver/DatabaseCleanup.java
@@ -38,9 +38,9 @@ public class DatabaseCleanup implements InitializingBean {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
         for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE  TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER  TABLE " + tableName +
-                    " ALTER  COLUMN  ID RESTART  WITH  1").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName +
+                    " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
         }
 
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();


### PR DESCRIPTION
DirtiesContext로 테스트 격리 하는 대신
인수테스트 시작 시 EntityManager를 사용하여 테이블을 TRUNCATE하는 식으로 변경했습니다.

적용 전 테스트 수행 시간은 1분 
적용 후 테스트 수행 시간은 11초로
현저히 줄어든것을 확인할 수 있었습니다.

https://devlopsquare.tistory.com/227
관련 내용 블로그에 정리해봤습니다! 