### PR TITLE
feat(client): 계좌등록 페이지 모바일 대응

### DIFF
--- a/client/main/src/components/Settlement/Register/SettlementRegisterForm.styles.ts
+++ b/client/main/src/components/Settlement/Register/SettlementRegisterForm.styles.ts
@@ -1,22 +1,41 @@
 import styled from 'styled-components';
+import { DEVICE } from '../../../constants/device';
 
 import SubTitle from '../../@atom/SubTitle/SubTitle.styles';
 import Title from '../../@atom/Title/Title.styles';
 import OutlineButton from '../../@molecule/OutlineButton/OutlineButton.styles';
 
 export const StyledSettlementAccountForm = styled.form`
-  padding: 3rem;
-  width: 37rem;
+  @media ${DEVICE.DESKTOP} {
+    padding: 3rem;
+    width: 32rem;
+  }
 `;
 
 export const SettlementAccountTitle = styled(Title)`
   margin-bottom: 6.5rem;
+  font-size: 1.75rem;
+
+  span {
+    display: block;
+  }
+
+  @media ${DEVICE.DESKTOP} {
+    font-size: 2rem;
+
+    span {
+      display: inline;
+    }
+  }
 `;
 
 export const StyledSubTitle = styled(SubTitle)`
   text-align: left;
   margin-bottom: 2.25rem;
-  font-size: 1.5rem;
+
+  @media ${DEVICE.DESKTOP} {
+    font-size: 1.5rem;
+  }
 `;
 
 export const InputContainer = styled.div`

--- a/client/main/src/components/Settlement/Register/SettlementRegisterForm.tsx
+++ b/client/main/src/components/Settlement/Register/SettlementRegisterForm.tsx
@@ -37,7 +37,9 @@ const SettlementRegisterForm = () => {
 
   return (
     <StyledSettlementAccountForm onSubmit={onSubmit}>
-      <SettlementAccountTitle>정산 받을 계좌 인증하기</SettlementAccountTitle>
+      <SettlementAccountTitle>
+        <span>정산 받을 계좌</span> <span>인증하기</span>
+      </SettlementAccountTitle>
 
       <InputContainer>
         <StyledSubTitle>이름</StyledSubTitle>

--- a/client/main/src/pages/Settlement/SettlementPage.tsx
+++ b/client/main/src/pages/Settlement/SettlementPage.tsx
@@ -35,9 +35,7 @@ const SettlementPage = () => {
       <StyledTitle>정산 관리</StyledTitle>
       <section>
         <Suspense fallback={Spinner}>
-          <Transition>
-            <Settlement />
-          </Transition>
+          <Settlement />
         </Suspense>
       </section>
     </StyledTemplate>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11311739/135227454-b4a5a4e5-2637-4776-b95d-b4d44dddd5eb.png)

transition 지운 이유는 transition때문에 은행선택 모바일 화면의 fixed가 깨져서 지움