### PR TITLE
fix(client): 타 창작자페이지에서 내 페이지로 이동시, 후원메시지리스트 갱신이 안되는 현상

### DIFF
--- a/client/main/src/service/creator/useDonationMessageList.ts
+++ b/client/main/src/service/creator/useDonationMessageList.ts
@@ -54,7 +54,7 @@ const useDonationMessageList = (isAdmin: boolean, creatorId: CreatorId) => {
         setHasMoreList(false);
       }
 
-      setDonationList(() => donationList.concat(nextDonationList));
+      setDonationList((prev) => prev.concat(nextDonationList));
       setCurrentPageIndex(currentPageIndex + 1);
     } catch (error) {
       alert('도네이션 메세지 목록을 불러오는데 실패했습니다.');
@@ -62,8 +62,9 @@ const useDonationMessageList = (isAdmin: boolean, creatorId: CreatorId) => {
   };
 
   useEffect(() => {
+    setDonationList([]);
     isAdmin ? initAdminDonationList() : initDonationList();
-  }, []);
+  }, [isAdmin]);
 
   return { donationList, showMoreDonationList, hasMoreList };
 };


### PR DESCRIPTION
1. 커스텀훅에서 didMount 이펙트훅에서 리스트 초기화
2. 내 후원리스트 불러오는 함수의 state, setState 콜백함수 적용