### PR TITLE
feat(client): 회원가입, 설정, 정산신청페이지 setState시 trim 적용

### DIFF
--- a/client/main/src/service/auth/useRegisterNickname.ts
+++ b/client/main/src/service/auth/useRegisterNickname.ts
@@ -66,7 +66,7 @@ const useRegisterNickname = () => {
   }, [nickname]);
 
   const setNickname = (value: string) => {
-    setUser({ ...user, nickname: value });
+    setUser({ ...user, nickname: value.trim() });
   };
 
   return {

--- a/client/main/src/service/auth/useRegisterPageName.ts
+++ b/client/main/src/service/auth/useRegisterPageName.ts
@@ -65,7 +65,7 @@ const useRegisterPageName = () => {
   }, [pageName]);
 
   const setPageName = (value: string) => {
-    setUser({ ...user, pageName: value });
+    setUser({ ...user, pageName: value.trim() });
   };
 
   return { pageName, addressErrorMessage, isValidAddress, setPageName };

--- a/client/main/src/service/settlement/useSettlementAccountForm.ts
+++ b/client/main/src/service/settlement/useSettlementAccountForm.ts
@@ -10,18 +10,18 @@ const useSettlementAccountForm = () => {
     bankbookImage: null,
   });
 
-  const setAccountHolder = (accountHolder: string) => {
-    setForm({ ...form, accountHolder });
+  const setAccountHolder = (value: string) => {
+    setForm({ ...form, accountHolder: value.trim() });
   };
 
   const setBank = (bank: string) => {
     setForm({ ...form, bank });
   };
 
-  const setAccountNumber = (accountNumber: string) => {
-    if (isNaN(Number(accountNumber))) return;
+  const setAccountNumber = (value: string) => {
+    if (isNaN(Number(value))) return;
 
-    setForm({ ...form, accountNumber });
+    setForm({ ...form, accountNumber: value.trim() });
   };
 
   const setBankbookImage = (bankbookImage: File) => {

--- a/client/main/src/service/user/useSettingForm.ts
+++ b/client/main/src/service/user/useSettingForm.ts
@@ -18,8 +18,8 @@ const useSettingForm = () => {
   });
   const { userInfo } = useUserInfo();
 
-  const setNickname = (nickname: string) => {
-    setForm({ ...form, nickname });
+  const setNickname = (value: string) => {
+    setForm({ ...form, nickname: value.trim() });
   };
 
   const setBio = (bio: string) => {


### PR DESCRIPTION
1. 설정페이지 닉네임
![image](https://user-images.githubusercontent.com/44419181/135741848-30db8806-3c6c-4a9a-b0ee-89c429d725e8.png)

2. 정산계좌신청 이름
![image](https://user-images.githubusercontent.com/44419181/135741863-19eb675b-e211-475a-a9c8-a7bab0d14f88.png)

3. 정산계좌신청 계좌번호 
![image](https://user-images.githubusercontent.com/44419181/135741865-478e050d-25f1-4dd8-abac-a478c451ee7f.png)

4. 회원가입 모든 텍스트 Input