### PR TITLE
fix(client): 어드민 페이지 accessToken 로그인 유지, 만료시 홈 이동 기능 수정

### DIFF
--- a/client/admin/src/constants/storage.ts
+++ b/client/admin/src/constants/storage.ts
@@ -1,0 +1,3 @@
+export const STORAGE_KEY = {
+  ACCESS_TOKEN: 'adminaccesstoken',
+};

--- a/client/admin/src/request/bankAccount.ts
+++ b/client/admin/src/request/bankAccount.ts
@@ -11,7 +11,9 @@ export const requestBankAccountList = async (accessToken: string) => {
     return response.json();
   }
 
-  throw Error('계좌 신청목록을 불러오는데 실패했습니다!');
+  return response.text().then((error) => {
+    throw JSON.parse(error);
+  });
 };
 
 export const requestAgreeBankAccount = async (userId: number, accessToken: string) => {

--- a/client/admin/src/request/settlement.ts
+++ b/client/admin/src/request/settlement.ts
@@ -12,7 +12,9 @@ export const requestExchangeList = async (accessToken: string) => {
     return response.json();
   }
 
-  throw Error('정산 신청목록을 불러오는데 실패했습니다!');
+  return response.text().then((error) => {
+    throw JSON.parse(error);
+  });
 };
 
 export const requestAgreeExchange = async (pageName: string, accessToken: string) => {

--- a/client/admin/src/service/@state/login.ts
+++ b/client/admin/src/service/@state/login.ts
@@ -1,7 +1,9 @@
 import { atom } from 'recoil';
+import { STORAGE_KEY } from '../../constants/storage';
+import { getLocalStorageItem } from '../../utils/storage';
 
 const getAccessToken = () => {
-  const token = sessionStorage.getItem('adminToken');
+  const token = getLocalStorageItem(STORAGE_KEY.ACCESS_TOKEN);
 
   if (token) return token;
   return '';

--- a/client/admin/src/service/useBankAccount.ts
+++ b/client/admin/src/service/useBankAccount.ts
@@ -22,6 +22,7 @@ const useBankAccount = () => {
       setBankAccountList(data);
     } catch (error) {
       alert(error.message);
+
       if (error.errorCode === 'auth-002') {
         history.push('/');
       }

--- a/client/admin/src/service/useLogin.ts
+++ b/client/admin/src/service/useLogin.ts
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
+import { STORAGE_KEY } from '../constants/storage';
 
 import { requestLogin } from '../request/login';
 import { LoginResponse } from '../type';
+import { setLocalStorageItem } from '../utils/storage';
 import { accessTokenState } from './@state/login';
 
 const useLogin = () => {
@@ -15,6 +17,7 @@ const useLogin = () => {
       const { token }: LoginResponse = await requestLogin(id, pwd);
 
       setAccessToken(token);
+      setLocalStorageItem(STORAGE_KEY.ACCESS_TOKEN, token);
 
       history.push('/bankAccount');
     } catch (error) {
@@ -25,6 +28,7 @@ const useLogin = () => {
   useEffect(() => {
     if (!accessToken) return;
 
+    localStorage.removeItem(STORAGE_KEY.ACCESS_TOKEN);
     setAccessToken('');
   }, []);
 

--- a/client/admin/src/service/useSettlement.ts
+++ b/client/admin/src/service/useSettlement.ts
@@ -18,10 +18,11 @@ const useSettlement = () => {
   const getExchangeList = async () => {
     try {
       const data: Exchange[] = await requestExchangeList(accessToken);
-      console.log(data);
+
       setExchangeList(data);
     } catch (error) {
       alert(error.message);
+
       if (error.errorCode === 'auth-002') {
         history.push('/');
       }

--- a/client/admin/src/utils/storage.ts
+++ b/client/admin/src/utils/storage.ts
@@ -1,0 +1,15 @@
+export const getLocalStorageItem = (key: string) => {
+  const item = localStorage.getItem(key);
+
+  if (!item) return null;
+
+  try {
+    return JSON.parse(item);
+  } catch (error) {
+    return item;
+  }
+};
+
+export const setLocalStorageItem = (key: string, item: unknown) => {
+  localStorage.setItem(key, JSON.stringify(item));
+};


### PR DESCRIPTION
- 이제 로그인후 새로고침해도 로그인 유지 됩니다 (localStorage 이용)
- 만료된 혹은 잘못된 accessToken으로 '정산신청목록', '계좌신청목록' 요청시 로그인 페이지(홈) 으로 이동합니다