### PR TITLE
feat(client): 도네이션 팝업에서 발생하는 이슈 해결

### DIFF
--- a/client/main/src/components/@molecule/Logo/Logo.tsx
+++ b/client/main/src/components/@molecule/Logo/Logo.tsx
@@ -27,6 +27,7 @@ export const FixedLogo = styled(IconButton).attrs({
 
   @media ${DEVICE.DESKTOP_LARGE} {
     width: 12rem;
+    height: auto;
   }
 `;
 

--- a/client/main/src/pages/Donation/Amount/DonationAmountPage.styles.ts
+++ b/client/main/src/pages/Donation/Amount/DonationAmountPage.styles.ts
@@ -1,6 +1,8 @@
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
 import Template from '../../../components/@atom/Template/Template';
+import PALETTE from '../../../constants/palette';
 import { Z_INDEX } from '../../../constants/style';
 
 export const popupStyle = css`
@@ -33,7 +35,13 @@ export const DonationAmountPageTemplate = styled(Template)`
   }
 `;
 
-export const PointAnchor = styled.a`
+export const PointAnchor = styled(Link)`
   font-weight: 600;
   font-size: 1.125rem;
+  color: ${PALETTE.BLACK_400};
+
+  &:active,
+  &:hover {
+    color: ${PALETTE.BLACK_400};
+  }
 `;

--- a/client/main/src/pages/Donation/Amount/DonationAmountPage.tsx
+++ b/client/main/src/pages/Donation/Amount/DonationAmountPage.tsx
@@ -24,7 +24,7 @@ const DonationAmountPage = () => {
     <DonationAmountPageTemplate>
       <FixedLogo onClick={() => popupWindow(window.location.origin)} />
       <section>
-        <PointAnchor href={`${window.location.origin}/mypoint`} target="_blank" rel="noreferrer">
+        <PointAnchor to={`/mypoint`} target="_blank" rel="noreferrer">
           {toCommaSeparatedString(userInfo?.point ?? 0)} tp
         </PointAnchor>
       </section>


### PR DESCRIPTION
- 현재 보유 포인트 클릭시 정상적으로 보유 포인트 조회 페이지로 넘어간다
- 현재 보유 포인트 기본 색상 제거
- 특정 너비에서 로고가 깨지는 현상 해결