### PR TITLE
hotfix: 계좌승인 로직에서 S3에서 통장사본 지우는 로직 제거

### DIFF
--- a/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
+++ b/server/src/main/java/com/example/tyfserver/admin/service/AdminService.java
@@ -10,7 +10,6 @@ import com.example.tyfserver.admin.exception.NotRegisteredAccountException;
 import com.example.tyfserver.auth.dto.TokenResponse;
 import com.example.tyfserver.auth.service.AuthenticationService;
 import com.example.tyfserver.common.util.Aes256Util;
-import com.example.tyfserver.common.util.S3Connector;
 import com.example.tyfserver.common.util.SmtpMailConnector;
 import com.example.tyfserver.donation.domain.Donation;
 import com.example.tyfserver.donation.repository.DonationRepository;
@@ -42,7 +41,6 @@ public class AdminService {
     private final DonationRepository donationRepository;
     private final MemberRepository memberRepository;
     private final SmtpMailConnector mailConnector;
-    private final S3Connector s3Connector;
     private final SmtpMailConnector smtpMailConnector;
     private final AdminAccount adminAccount;
     private final AuthenticationService authenticationService;
@@ -51,7 +49,6 @@ public class AdminService {
     public void approveAccount(Long memberId) {
         Member member = findMember(memberId);
         member.approveAccount();
-        s3Connector.delete(member.getBankBookUrl());
         smtpMailConnector.sendAccountApprove(member.getEmail());
     }
 


### PR DESCRIPTION
- 통장사본으로 계좌 인증하던 로직 제거로 발생한 이슈
- 추후 멤버 도메인의 bankbookurl 제거 필요