### PR TITLE
feat(server): 히카리 풀 설정 및 gzip 설정

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -5,6 +5,14 @@ spring:
 #    url: jdbc:mysql://localhost:13306/flywaytest?serverTimezone=UTC&characterEncoding=UTF-8
     username: sa
     password:
+    hikari:
+      pool-name: tyfHikari
+      maximum-pool-size: 60
+      data-source-properties:
+        cachePrepStmts: true
+        prepStmtCacheSize: 250
+        prepStmtCacheSqllLimit: 2048
+        useServerPrepStmts: true
 
   h2:
     console:
@@ -79,4 +87,8 @@ aes:
     tyftesttyftesttyftesttyftesttyft
 
 batch_size: 1000
+
+server:
+  compression:
+    enabled: true
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     password:
     hikari:
       pool-name: tyfHikari
-      maximum-pool-size: 50
+      maximum-pool-size: 10
       data-source-properties:
         cachePrepStmts: true
         prepStmtCacheSize: 250

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -8,11 +8,6 @@ spring:
     hikari:
       pool-name: tyfHikari
       maximum-pool-size: 10
-      data-source-properties:
-        cachePrepStmts: true
-        prepStmtCacheSize: 250
-        prepStmtCacheSqllLimit: 2048
-        useServerPrepStmts: true
 
   h2:
     console:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     password:
     hikari:
       pool-name: tyfHikari
-      maximum-pool-size: 60
+      maximum-pool-size: 50
       data-source-properties:
         cachePrepStmts: true
         prepStmtCacheSize: 250


### PR DESCRIPTION
close #539 

[gzip 설정 참고 링크](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.webserver.enable-response-compression)

[히카리 풀 설정 참고 링크](https://hyunsoori.tistory.com/2)

처음에는 우리가 성능측정을 했던 것 처럼 목표 VU에 맞춰서 hikari pool-size를 조정하는게 맞지 않나? 라는 생각을 했어  
그런데, 모든 요청이 db를 타는 것도 아니고(우리의 경우 다 타지만) 모든 요청의 개수에 맞게끔 커넥션을 가지는 것도 비효율적이라는 것을 깨달았어. 핵심적으로는 히카리풀의 공식 문서에 나와있는 이 설명 때문에 기본설정인 10개의 size를 변경하지 않게 됐어  
![image](https://user-images.githubusercontent.com/45073750/141320613-4569318c-db37-4417-b666-0f7f396a6a27.png)

결론: 히카리풀 사이즈를 변경하려 했으나 변경안했다. cache 전략도 적용하려다 적용안했다. 그냥 hikari cp의 name과 size 명시만 해주었다.

그리고 추가적으로 이 링크들을 읽으면 좋을 것 같아! 좀 많이 도움되는 것 같아.
https://jeong-pro.tistory.com/204  
https://jaehun2841.github.io/2020/01/27/2020-01-27-hikaricp-maximum-pool-size-tuning/#generatedvaluestrategy-generationtypeauto  
https://hyuntaeknote.tistory.com/12  
https://www.holaxprogramming.com/2013/01/10/devops-how-to-manage-dbcp/  
https://d2.naver.com/helloworld/5102792  

